### PR TITLE
Add SizePartitioningStore

### DIFF
--- a/cas/store/BUILD
+++ b/cas/store/BUILD
@@ -27,6 +27,7 @@ rust_library(
         ":memory_store",
         ":ref_store",
         ":s3_store",
+        ":size_partitioning_store",
         ":store",
         ":traits",
         ":verify_store",
@@ -44,6 +45,20 @@ rust_library(
         "//util:buf_channel",
         "//util:common",
         "//util:error",
+    ],
+    proc_macro_deps = ["//third_party:async_trait"],
+    visibility = ["//cas:__pkg__"]
+)
+
+rust_library(
+    name = "size_partitioning_store",
+    srcs = ["size_partitioning_store.rs"],
+    deps = [
+        "//config",
+        "//util:buf_channel",
+        "//util:common",
+        "//util:error",
+        ":traits",
     ],
     proc_macro_deps = ["//third_party:async_trait"],
     visibility = ["//cas:__pkg__"]
@@ -199,6 +214,21 @@ rust_library(
     ],
     proc_macro_deps = ["//third_party:async_trait"],
     visibility = ["//cas:__pkg__"]
+)
+
+rust_test(
+    name = "size_partitioning_store_test",
+    srcs = ["tests/size_partitioning_store_test.rs"],
+    deps = [
+        "//config",
+        "//third_party:pretty_assertions",
+        "//third_party:tokio",
+        "//util:common",
+        "//util:error",
+        ":memory_store",
+        ":size_partitioning_store",
+        ":traits",
+    ],
 )
 
 rust_test(

--- a/cas/store/default_store_factory.rs
+++ b/cas/store/default_store_factory.rs
@@ -13,6 +13,7 @@ use futures::Future;
 use memory_store::MemoryStore;
 use ref_store::RefStore;
 use s3_store::S3Store;
+use size_partitioning_store::SizePartitioningStore;
 use store::{Store, StoreManager};
 use verify_store::VerifyStore;
 
@@ -44,6 +45,11 @@ pub fn store_factory<'a>(
             )),
             StoreConfig::filesystem(config) => Arc::new(FilesystemStore::new(&config).await?),
             StoreConfig::ref_store(config) => Arc::new(RefStore::new(&config, store_manager.clone())),
+            StoreConfig::size_partitioning(config) => Arc::new(SizePartitioningStore::new(
+                &config,
+                store_factory(&config.lower_store, store_manager).await?,
+                store_factory(&config.upper_store, store_manager).await?,
+            )),
         };
         Ok(store)
     })

--- a/cas/store/size_partitioning_store.rs
+++ b/cas/store/size_partitioning_store.rs
@@ -1,0 +1,75 @@
+// Copyright 2022 Nathan (Blaise) Bruer.  All rights reserved.
+
+use std::pin::Pin;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use buf_channel::{DropCloserReadHalf, DropCloserWriteHalf};
+use common::DigestInfo;
+use config;
+use error::Error;
+use traits::{StoreTrait, UploadSizeInfo};
+
+pub struct SizePartitioningStore {
+    size: i64,
+    lower_store: Arc<dyn StoreTrait>,
+    upper_store: Arc<dyn StoreTrait>,
+}
+
+impl SizePartitioningStore {
+    pub fn new(
+        config: &config::backends::SizePartitioningStore,
+        lower_store: Arc<dyn StoreTrait>,
+        upper_store: Arc<dyn StoreTrait>,
+    ) -> Self {
+        SizePartitioningStore {
+            size: config.size as i64,
+            lower_store,
+            upper_store,
+        }
+    }
+}
+
+#[async_trait]
+impl StoreTrait for SizePartitioningStore {
+    async fn has(self: Pin<&Self>, digest: DigestInfo) -> Result<Option<usize>, Error> {
+        if digest.size_bytes < self.size {
+            return Pin::new(self.lower_store.as_ref()).has(digest).await;
+        }
+        Pin::new(self.upper_store.as_ref()).has(digest).await
+    }
+
+    async fn update(
+        self: Pin<&Self>,
+        digest: DigestInfo,
+        reader: DropCloserReadHalf,
+        size_info: UploadSizeInfo,
+    ) -> Result<(), Error> {
+        if digest.size_bytes < self.size {
+            return Pin::new(self.lower_store.as_ref())
+                .update(digest, reader, size_info)
+                .await;
+        }
+        Pin::new(self.upper_store.as_ref())
+            .update(digest, reader, size_info)
+            .await
+    }
+
+    async fn get_part(
+        self: Pin<&Self>,
+        digest: DigestInfo,
+        writer: DropCloserWriteHalf,
+        offset: usize,
+        length: Option<usize>,
+    ) -> Result<(), Error> {
+        if digest.size_bytes < self.size {
+            return Pin::new(self.lower_store.as_ref())
+                .get_part(digest, writer, offset, length)
+                .await;
+        }
+        Pin::new(self.upper_store.as_ref())
+            .get_part(digest, writer, offset, length)
+            .await
+    }
+}

--- a/cas/store/tests/size_partitioning_store_test.rs
+++ b/cas/store/tests/size_partitioning_store_test.rs
@@ -1,0 +1,172 @@
+// Copyright 2022 Nathan (Blaise) Bruer.  All rights reserved.
+
+use std::pin::Pin;
+use std::sync::Arc;
+
+#[cfg(test)]
+mod ref_store_tests {
+    use super::*;
+    use pretty_assertions::assert_eq; // Must be declared in every module.
+
+    use error::Error;
+
+    use common::DigestInfo;
+    use config;
+    use memory_store::MemoryStore;
+    use size_partitioning_store::SizePartitioningStore;
+    use traits::StoreTrait;
+
+    const BASE_SIZE_PART: u64 = 5;
+
+    const SMALL_HASH: &str = "0123456789abcdef000000000000000000010000000000000123456789abcdef";
+    const SMALL_VALUE: &str = "99";
+
+    const BIG_HASH: &str = "0123456789abcdef000000000000000000010000000000000123456789abcdef";
+    const BIG_VALUE: &str = "123456789";
+
+    fn setup_stores(size: u64) -> (SizePartitioningStore, Arc<MemoryStore>, Arc<MemoryStore>) {
+        let lower_memory_store = Arc::new(MemoryStore::new(&config::backends::MemoryStore::default()));
+        let upper_memory_store = Arc::new(MemoryStore::new(&config::backends::MemoryStore::default()));
+
+        let size_part_store = SizePartitioningStore::new(
+            &config::backends::SizePartitioningStore {
+                size,
+                lower_store: config::backends::StoreConfig::memory(config::backends::MemoryStore::default()),
+                upper_store: config::backends::StoreConfig::memory(config::backends::MemoryStore::default()),
+            },
+            lower_memory_store.clone(),
+            upper_memory_store.clone(),
+        );
+        (size_part_store, lower_memory_store, upper_memory_store)
+    }
+
+    #[tokio::test]
+    async fn has_test() -> Result<(), Error> {
+        let (size_part_store, lower_memory_store, upper_memory_store) = setup_stores(BASE_SIZE_PART);
+
+        {
+            // Insert data into lower store.
+            Pin::new(lower_memory_store.as_ref())
+                .update_oneshot(DigestInfo::try_new(&SMALL_HASH, SMALL_VALUE.len())?, SMALL_VALUE.into())
+                .await?;
+
+            // Insert data into upper store.
+            Pin::new(upper_memory_store.as_ref())
+                .update_oneshot(DigestInfo::try_new(&BIG_HASH, BIG_VALUE.len())?, BIG_VALUE.into())
+                .await?;
+        }
+        {
+            // Check if our partition store has small data.
+            let small_has_result = Pin::new(&size_part_store)
+                .has(DigestInfo::try_new(&SMALL_HASH, SMALL_VALUE.len())?)
+                .await;
+            assert_eq!(
+                small_has_result,
+                Ok(Some(SMALL_VALUE.len())),
+                "Expected size part store to have data in ref store : {}",
+                SMALL_HASH
+            );
+        }
+        {
+            // Check if our partition store has big data.
+            let small_has_result = Pin::new(&size_part_store)
+                .has(DigestInfo::try_new(&BIG_HASH, BIG_VALUE.len())?)
+                .await;
+            assert_eq!(
+                small_has_result,
+                Ok(Some(BIG_VALUE.len())),
+                "Expected size part store to have data in ref store : {}",
+                BIG_HASH
+            );
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn get_test() -> Result<(), Error> {
+        let (size_part_store, lower_memory_store, upper_memory_store) = setup_stores(BASE_SIZE_PART);
+
+        {
+            // Insert data into lower store.
+            Pin::new(lower_memory_store.as_ref())
+                .update_oneshot(DigestInfo::try_new(&SMALL_HASH, SMALL_VALUE.len())?, SMALL_VALUE.into())
+                .await?;
+
+            // Insert data into upper store.
+            Pin::new(upper_memory_store.as_ref())
+                .update_oneshot(DigestInfo::try_new(&BIG_HASH, BIG_VALUE.len())?, BIG_VALUE.into())
+                .await?;
+        }
+        {
+            // Read the partition store small data.
+            let data = Pin::new(&size_part_store)
+                .get_part_unchunked(DigestInfo::try_new(&SMALL_HASH, SMALL_VALUE.len())?, 0, None, None)
+                .await
+                .expect("Get should have succeeded");
+            assert_eq!(
+                data,
+                SMALL_VALUE.as_bytes(),
+                "Expected size part store to have data in ref store : {}",
+                SMALL_HASH
+            );
+        }
+        {
+            // Read the partition store big data.
+            let data = Pin::new(&size_part_store)
+                .get_part_unchunked(DigestInfo::try_new(&BIG_HASH, BIG_VALUE.len())?, 0, None, None)
+                .await
+                .expect("Get should have succeeded");
+            assert_eq!(
+                data,
+                BIG_VALUE.as_bytes(),
+                "Expected size part store to have data in ref store : {}",
+                BIG_HASH
+            );
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn update_test() -> Result<(), Error> {
+        let (size_part_store, lower_memory_store, upper_memory_store) = setup_stores(BASE_SIZE_PART);
+
+        {
+            // Insert small data into ref_store.
+            Pin::new(&size_part_store)
+                .update_oneshot(DigestInfo::try_new(&SMALL_HASH, SMALL_VALUE.len())?, SMALL_VALUE.into())
+                .await?;
+
+            // Insert small data into ref_store.
+            Pin::new(&size_part_store)
+                .update_oneshot(DigestInfo::try_new(&BIG_HASH, BIG_VALUE.len())?, BIG_VALUE.into())
+                .await?;
+        }
+        {
+            // Check if we read small data from size_partition_store it has same data.
+            let data = Pin::new(lower_memory_store.as_ref())
+                .get_part_unchunked(DigestInfo::try_new(&SMALL_HASH, SMALL_VALUE.len())?, 0, None, None)
+                .await
+                .expect("Get should have succeeded");
+            assert_eq!(
+                data,
+                SMALL_VALUE.as_bytes(),
+                "Expected size part store to have data in memory store : {}",
+                SMALL_HASH
+            );
+        }
+        {
+            // Check if we read big data from size_partition_store it has same data.
+            let data = Pin::new(upper_memory_store.as_ref())
+                .get_part_unchunked(DigestInfo::try_new(&BIG_HASH, BIG_VALUE.len())?, 0, None, None)
+                .await
+                .expect("Get should have succeeded");
+            assert_eq!(
+                data,
+                BIG_VALUE.as_bytes(),
+                "Expected size part store to have data in memory store : {}",
+                BIG_HASH
+            );
+        }
+        Ok(())
+    }
+}

--- a/config/backends.rs
+++ b/config/backends.rs
@@ -92,6 +92,27 @@ pub enum StoreConfig {
     /// used for the action cache, but use a FastSlowStore and have the fast
     /// store also share the memory store for efficiency.
     ref_store(RefStore),
+
+    /// Uses the size field of the digest to separate which store to send the
+    /// data. This is useful for cases when you'd like to put small objects
+    /// in one store and large objects in another store. This should only be
+    /// used if the size field is the real size of the content, in other
+    /// words, don't use on AC (Action Cache) stores. Any store where you can
+    /// safely use VerifyStore.verify_size = true, this store should be safe
+    /// to use (ie: CAS stores).
+    size_partitioning(Box<SizePartitioningStore>),
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct SizePartitioningStore {
+    /// Size to partition the data on.
+    pub size: u64,
+
+    /// Store to send data when object is < (less than) size.
+    pub lower_store: StoreConfig,
+
+    /// Store to send data when object is >= (less than eq) size.
+    pub upper_store: StoreConfig,
 }
 
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]

--- a/config/examples/filesystem_cas.json
+++ b/config/examples/filesystem_cas.json
@@ -1,3 +1,8 @@
+// This configuration will place objects in various folders in
+// `/tmp/turbo_cache_data`. It will store all data on disk and
+// allows for restarts of the underlying service. It is optimized
+// so objects are compressed, deduplicated and uses some in-memory
+// optimizations for certain hot paths.
 {
   "stores": {
     "FS_CONTENT_STORE": {
@@ -20,20 +25,52 @@
     "CAS_MAIN_STORE": {
       "verify": {
         "backend": {
-          "dedup": {
-            "index_store": {
-              "filesystem": {
-                "content_path": "/tmp/turbo_cache_data/content_path-index",
-                "temp_path": "/tmp/turbo_cache_data/tmp_path-index",
-                "eviction_policy": {
-                  // 500mb.
-                  "max_bytes": 500000000,
-                }
-              }
-            },
-            "content_store": {
+          // Because we are using a dedup store, we can bypass small objects
+          // and put those objects directly into the content store without
+          // having to be indexed. This greatly improves performance of serving
+          // general build content, since many objects are quite small and by
+          // putting this size distinguish store in place will prevent 1+ index
+          // read/write per small object request.
+          "size_partitioning": {
+            "size": 262144, // 256k.
+            "lower_store": {
               "ref_store": {
                 "name": "FS_CONTENT_STORE"
+              }
+            },
+            "upper_store": {
+              "dedup": {
+                "index_store": {
+                  // Since our index store is queried so much, we use a fast_slow
+                  // store so it will keep in memory objects that are accessed
+                  // frequently before going to disk.
+                  // Note: indexes are generally quite small, but accessed frequently.
+                  "fast_slow": {
+                    "fast": {
+                      "memory": {
+                        "eviction_policy": {
+                          // 10mb.
+                          "max_bytes": 10000000,
+                        }
+                      }
+                    },
+                    "slow": {
+                      "filesystem": {
+                        "content_path": "/tmp/turbo_cache_data/content_path-index",
+                        "temp_path": "/tmp/turbo_cache_data/tmp_path-index",
+                        "eviction_policy": {
+                          // 500mb.
+                          "max_bytes": 500000000,
+                        }
+                      }
+                    }
+                  }
+                },
+                "content_store": {
+                  "ref_store": {
+                    "name": "FS_CONTENT_STORE"
+                  }
+                }
               }
             }
           }


### PR DESCRIPTION
This new store can be used to partition objects based on the size
listed in the digest.

In addition, the filesystem_cas.json has been changed to take
advantage of the new config.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/allada/turbo-cache/46)
<!-- Reviewable:end -->
