### PR TITLE
[RE] Various changes to worker_api.proto

### DIFF
--- a/proto/com/github/allada/turbo_cache/remote_execution/worker_api.proto
+++ b/proto/com/github/allada/turbo_cache/remote_execution/worker_api.proto
@@ -15,48 +15,38 @@ import "google/protobuf/empty.proto";
 /// command to the scheduler. The scheduler will then use this information
 /// to determine which jobs the worker can process.
 service WorkerApi {
-    /// The worker will run this connect command which will initiate the
-    /// bi-directional stream. The worker must first run
-    /// `RegisterSupportedProperties` before issuing any other commands.
-    rpc ConnectWorker(stream UpdateFromWorker) returns (stream UpdateForWorker);
-}
+    /// Registers this worker and informs the scheduler what properties
+    /// this worker supports. The response must be listened on the client
+    /// side for updates from the server.
+    rpc ConnectWorker(SupportedProperties) returns (stream UpdateForWorker);
 
-/// Communication from the worker to the scheduler.
-message UpdateFromWorker {
-    oneof update {
-        /// Message used to let the scheduler know that it is still alive as
-        /// well as check to see if the scheduler is still alive. The scheduler
-        /// may close the connection if the worker has not sent any messages
-        /// after some amount of time (configured in the scheduler's
-        /// configuration).
-        google.protobuf.Empty keep_alive = 1;
+    /// Message used to let the scheduler know that it is still alive as
+    /// well as check to see if the scheduler is still alive. The scheduler
+    /// may close the connection if the worker has not sent any messages
+    /// after some amount of time (configured in the scheduler's
+    /// configuration).
+    rpc KeepAlive(google.protobuf.Empty) returns (google.protobuf.Empty);
 
-        /// Registers this worker and informs the scheduler what properties
-        /// this worker supports. This command MUST be sent before issuing
-        /// any other commands. Failing to do so is undefined behavior.
-        RegisterSupportedProperties register_supported_properties = 2;
+    /// Informs the scheduler that the service is going offline and
+    /// should stop issuing any new actions on this worker.
+    ///
+    /// The worker may stay connected even after sending this command
+    /// and may even send an `ExecuteResult` after sending this command.
+    /// It is up to the scheduler implementation to decide how to handle
+    /// this case.
+    ///
+    /// Any job that was running on this instance likely needs to be
+    /// executed again, but up to the scheduler on how or when to handle
+    /// this case.
+    rpc GoingAway(google.protobuf.Empty) returns (google.protobuf.Empty);
 
-        /// Informs the scheduler about the result of an execution request.
-        ExecuteResult execute_result = 3;
-
-        /// Informs the scheduler that the service is going offline and
-        /// should stop issuing any new actions on this worker.
-        ///
-        /// The worker may stay connected even after sending this command
-        /// and may even send an `ExecuteResult` after sending this command.
-        /// It is up to the scheduler implementation to decide how to handle
-        /// this case.
-        ///
-        /// Any job that was running on this instance likely needs to be
-        /// executed again, but up to the scheduler on how or when to handle
-        /// this case.
-        GoingAway going_away = 4;
-    }
+    /// Informs the scheduler about the result of an execution request.
+    rpc ExecutionResponse(ExecuteResult) returns (google.protobuf.Empty);
 }
 
 /// Represents the initial request sent to the scheduler informing the
 /// scheduler about this worker's capabilities.
-message RegisterSupportedProperties {
+message SupportedProperties {
     /// The list of properties this worker can support. The exact
     /// implementation is driven by the configuration matrix between the
     /// worker and scheduler.
@@ -68,6 +58,7 @@ message RegisterSupportedProperties {
     /// The details on how to use this property can be found here:
     /// https://github.com/allada/turbo-cache/blob/c91f61edf182f2b64451fd48a5e63fa506a43aae/config/cas_server.rs
     repeated build.bazel.remote.execution.v2.Platform.Property properties = 1;
+    reserved 2; // NextId.
 }
 
 /// Represents the result of an execution.
@@ -75,27 +66,38 @@ message ExecuteResult {
     /// Result of the execution. See `build.bazel.remote.execution.v2.ExecuteResponse`
     /// for details.
     build.bazel.remote.execution.v2.ExecuteResponse execute_response = 1;
+    reserved 2; // NextId.
 }
 
-/// Informs the scheduler that the node is going offline.
-message GoingAway {}
+/// Result sent back from the server when a node connects.
+message ConnectionResult {
+    /// The internal ID given to the newly connected node.
+    string worker_id = 1;
+    reserved 2; // NextId.
+}
 
 /// Communication from the scheduler to the worker.
 message UpdateForWorker {
     oneof update {
+        /// This will be sent only as the first item in the stream after the node
+        /// has connected.
+        ConnectionResult connection_result = 1;
+
         /// Message used to let the worker know that it is still alive as well
         /// as check to see if the worker is still alive. The worker
         /// may close the connection if the scheduler has not sent any messages
         /// after some amount of time (configured in the scheduler's
         /// configuration).
-        google.protobuf.Empty keep_alive = 1;
+        google.protobuf.Empty keep_alive = 2;
 
         /// Informs the worker about some work it should begin performing the
         /// requested action.
-        StartExecute start_action = 2;
+        StartExecute start_action = 3;
     }
+    reserved 4; // NextId.
 }
 
 message StartExecute {
     build.bazel.remote.execution.v2.ExecuteRequest execute_request = 1;
+    reserved 2; // NextId.
 }


### PR DESCRIPTION
* ConnectWorker is no longer stream<->stream, instead has function
  calls and returns a stream for server->client updates.
* Added `reserved` keyword representing each `NextId`.
* Added ConnectionResult so worker itself knows it's own ID.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/allada/turbo-cache/48)
<!-- Reviewable:end -->
