### PR TITLE
[RE] Add WorkerApiService and connection functionality

### DIFF
--- a/cas/grpc_service/BUILD
+++ b/cas/grpc_service/BUILD
@@ -91,6 +91,24 @@ rust_library(
 )
 
 rust_library(
+    name = "worker_api_server",
+    srcs = ["worker_api_server.rs"],
+    deps = [
+        "//cas/scheduler",
+        "//cas/scheduler:platform_property_manager",
+        "//cas/scheduler:worker",
+        "//proto",
+        "//third_party:futures",
+        "//third_party:tokio",
+        "//third_party:tonic",
+        "//third_party:uuid",
+        "//util:common",
+        "//util:error",
+    ],
+    visibility = ["//cas:__pkg__"]
+)
+
+rust_library(
     name = "ac_utils",
     srcs = ["ac_utils.rs"],
     deps = [
@@ -100,6 +118,22 @@ rust_library(
         "//util:error",
     ],
     visibility = ["//visibility:public"],
+)
+
+rust_test(
+    name = "worker_api_server_test",
+    srcs = ["tests/worker_api_server_test.rs"],
+    deps = [
+        "//cas/scheduler",
+        "//cas/scheduler:platform_property_manager",
+        "//proto",
+        "//third_party:pretty_assertions",
+        "//third_party:tokio",
+        "//third_party:tokio_stream",
+        "//third_party:tonic",
+        "//util:error",
+        ":worker_api_server",
+    ],
 )
 
 rust_test(

--- a/cas/grpc_service/tests/worker_api_server_test.rs
+++ b/cas/grpc_service/tests/worker_api_server_test.rs
@@ -1,0 +1,57 @@
+// Copyright 2022 Nathan (Blaise) Bruer.  All rights reserved.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use tokio_stream::StreamExt;
+use tonic::Request;
+
+use error::ResultExt;
+use platform_property_manager::PlatformPropertyManager;
+use proto::com::github::allada::turbo_cache::remote_execution::{
+    update_for_worker, worker_api_server::WorkerApi, SupportedProperties,
+};
+use scheduler::Scheduler;
+use worker_api_server::WorkerApiServer;
+
+#[cfg(test)]
+pub mod connect_worker_tests {
+    use super::*;
+    use pretty_assertions::assert_eq; // Must be declared in every module.
+
+    #[tokio::test]
+    pub async fn connect_worker_adds_worker_to_scheduler_test() -> Result<(), Box<dyn std::error::Error>> {
+        let platform_properties = HashMap::new();
+        let scheduler = Arc::new(Scheduler::new());
+        let worker_api_server = WorkerApiServer::new(
+            Arc::new(PlatformPropertyManager::new(platform_properties)),
+            scheduler.clone(),
+        );
+
+        let supported_properties = SupportedProperties::default();
+        let mut update_for_worker_stream = worker_api_server
+            .connect_worker(Request::new(supported_properties))
+            .await?
+            .into_inner();
+
+        let maybe_first_message = update_for_worker_stream.next().await;
+        assert!(maybe_first_message.is_some(), "Expected first message from stream");
+        let first_update = maybe_first_message
+            .unwrap()
+            .err_tip(|| "Expected success result")?
+            .update
+            .err_tip(|| "Expected update field to be populated")?;
+        let worker_id = match first_update {
+            update_for_worker::Update::ConnectionResult(connection_result) => connection_result.worker_id,
+            other => unreachable!("Expected ConnectionResult, got {:?}", other),
+        };
+
+        const UUID_SIZE: usize = 36;
+        assert_eq!(worker_id.len(), UUID_SIZE, "Worker ID should be 36 characters");
+
+        let worker_exists = scheduler.contains_worker_for_test(&worker_id.try_into()?).await;
+        assert!(worker_exists, "Expected worker to exist in worker map");
+
+        Ok(())
+    }
+}

--- a/cas/scheduler/BUILD
+++ b/cas/scheduler/BUILD
@@ -33,6 +33,7 @@ rust_library(
     deps = [
         "//proto",
         "//third_party:tokio",
+        "//third_party:uuid",
         "//util:error",
         ":action_messages",
         ":platform_property_manager",


### PR DESCRIPTION
Adds server side connection API server to allow the worker to
interface with the scheduler. This PR only adds the connect_worker().

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/allada/turbo-cache/49)
<!-- Reviewable:end -->
