### PR TITLE
Add support for keep alive for workers

### DIFF
--- a/cas/grpc_service/BUILD
+++ b/cas/grpc_service/BUILD
@@ -81,6 +81,7 @@ rust_library(
         "//third_party:futures",
         "//third_party:rand",
         "//third_party:stdext",
+        "//third_party:tokio",
         "//third_party:tokio_stream",
         "//third_party:tonic",
         "//util:common",
@@ -126,6 +127,7 @@ rust_test(
     deps = [
         "//cas/scheduler",
         "//cas/scheduler:platform_property_manager",
+        "//cas/scheduler:worker",
         "//proto",
         "//third_party:pretty_assertions",
         "//third_party:tokio",

--- a/cas/grpc_service/tests/worker_api_server_test.rs
+++ b/cas/grpc_service/tests/worker_api_server_test.rs
@@ -2,55 +2,189 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Duration;
 
 use tokio_stream::StreamExt;
 use tonic::Request;
 
-use error::ResultExt;
+use error::{Error, ResultExt};
 use platform_property_manager::PlatformPropertyManager;
 use proto::com::github::allada::turbo_cache::remote_execution::{
-    update_for_worker, worker_api_server::WorkerApi, SupportedProperties,
+    update_for_worker, worker_api_server::WorkerApi, KeepAliveRequest, SupportedProperties,
 };
 use scheduler::Scheduler;
-use worker_api_server::WorkerApiServer;
+use worker::WorkerId;
+use worker_api_server::{ConnectWorkerStream, NowFn, WorkerApiServer};
+
+const BASE_NOW_S: u64 = 10;
+const BASE_WORKER_TIMEOUT_S: u64 = 100;
+
+struct TestContext {
+    scheduler: Arc<Scheduler>,
+    worker_api_server: WorkerApiServer,
+    connection_worker_stream: ConnectWorkerStream,
+    worker_id: WorkerId,
+}
+
+fn static_now_fn() -> Result<Duration, Error> {
+    Ok(Duration::from_secs(BASE_NOW_S))
+}
+
+async fn setup_api_server(worker_timeout: u64, now_fn: &'static NowFn) -> Result<TestContext, Error> {
+    let platform_properties = HashMap::new();
+    let scheduler = Arc::new(Scheduler::new(worker_timeout));
+    let worker_api_server = WorkerApiServer::new_with_now_fn(
+        Arc::new(PlatformPropertyManager::new(platform_properties)),
+        scheduler.clone(),
+        now_fn,
+    );
+
+    let supported_properties = SupportedProperties::default();
+    let mut connection_worker_stream = worker_api_server
+        .connect_worker(Request::new(supported_properties))
+        .await?
+        .into_inner();
+
+    let maybe_first_message = connection_worker_stream.next().await;
+    assert!(maybe_first_message.is_some(), "Expected first message from stream");
+    let first_update = maybe_first_message
+        .unwrap()
+        .err_tip(|| "Expected success result")?
+        .update
+        .err_tip(|| "Expected update field to be populated")?;
+    let worker_id = match first_update {
+        update_for_worker::Update::ConnectionResult(connection_result) => connection_result.worker_id,
+        other => unreachable!("Expected ConnectionResult, got {:?}", other),
+    };
+
+    const UUID_SIZE: usize = 36;
+    assert_eq!(worker_id.len(), UUID_SIZE, "Worker ID should be 36 characters");
+
+    Ok(TestContext {
+        scheduler,
+        worker_api_server,
+        connection_worker_stream,
+        worker_id: worker_id.try_into()?,
+    })
+}
 
 #[cfg(test)]
 pub mod connect_worker_tests {
     use super::*;
-    use pretty_assertions::assert_eq; // Must be declared in every module.
 
     #[tokio::test]
     pub async fn connect_worker_adds_worker_to_scheduler_test() -> Result<(), Box<dyn std::error::Error>> {
-        let platform_properties = HashMap::new();
-        let scheduler = Arc::new(Scheduler::new());
-        let worker_api_server = WorkerApiServer::new(
-            Arc::new(PlatformPropertyManager::new(platform_properties)),
-            scheduler.clone(),
-        );
+        let test_context = setup_api_server(BASE_WORKER_TIMEOUT_S, &static_now_fn).await?;
 
-        let supported_properties = SupportedProperties::default();
-        let mut update_for_worker_stream = worker_api_server
-            .connect_worker(Request::new(supported_properties))
-            .await?
-            .into_inner();
-
-        let maybe_first_message = update_for_worker_stream.next().await;
-        assert!(maybe_first_message.is_some(), "Expected first message from stream");
-        let first_update = maybe_first_message
-            .unwrap()
-            .err_tip(|| "Expected success result")?
-            .update
-            .err_tip(|| "Expected update field to be populated")?;
-        let worker_id = match first_update {
-            update_for_worker::Update::ConnectionResult(connection_result) => connection_result.worker_id,
-            other => unreachable!("Expected ConnectionResult, got {:?}", other),
-        };
-
-        const UUID_SIZE: usize = 36;
-        assert_eq!(worker_id.len(), UUID_SIZE, "Worker ID should be 36 characters");
-
-        let worker_exists = scheduler.contains_worker_for_test(&worker_id.try_into()?).await;
+        let worker_exists = test_context
+            .scheduler
+            .contains_worker_for_test(&test_context.worker_id)
+            .await;
         assert!(worker_exists, "Expected worker to exist in worker map");
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+pub mod keep_alive_tests {
+    use super::*;
+    use pretty_assertions::assert_eq; // Must be declared in every module.
+
+    #[tokio::test]
+    pub async fn server_times_out_workers_test() -> Result<(), Box<dyn std::error::Error>> {
+        let test_context = setup_api_server(BASE_WORKER_TIMEOUT_S, &static_now_fn).await?;
+
+        let mut now_timestamp = BASE_NOW_S;
+        {
+            // Now change time to 1 second before timeout and ensure the worker is still in the pool.
+            now_timestamp += BASE_WORKER_TIMEOUT_S - 1;
+            test_context.scheduler.remove_timedout_workers(now_timestamp).await?;
+            let worker_exists = test_context
+                .scheduler
+                .contains_worker_for_test(&test_context.worker_id)
+                .await;
+            assert!(worker_exists, "Expected worker to exist in worker map");
+        }
+        {
+            // Now add 1 second and our worker should have been evicted due to timeout.
+            now_timestamp += 1;
+            test_context.scheduler.remove_timedout_workers(now_timestamp).await?;
+            let worker_exists = test_context
+                .scheduler
+                .contains_worker_for_test(&test_context.worker_id)
+                .await;
+            assert!(!worker_exists, "Expected worker to not exist in map");
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    pub async fn server_does_not_timeout_if_keep_alive_test() -> Result<(), Box<dyn std::error::Error>> {
+        let test_context = setup_api_server(BASE_WORKER_TIMEOUT_S, &static_now_fn).await?;
+
+        let mut now_timestamp = BASE_NOW_S;
+        {
+            // Now change time to 1 second before timeout and ensure the worker is still in the pool.
+            now_timestamp += BASE_WORKER_TIMEOUT_S - 1;
+            test_context.scheduler.remove_timedout_workers(now_timestamp).await?;
+            let worker_exists = test_context
+                .scheduler
+                .contains_worker_for_test(&test_context.worker_id)
+                .await;
+            assert!(worker_exists, "Expected worker to exist in worker map");
+        }
+        {
+            // Now send keep alive.
+            test_context
+                .worker_api_server
+                .keep_alive(Request::new(KeepAliveRequest {
+                    worker_id: test_context.worker_id.to_string(),
+                }))
+                .await
+                .err_tip(|| "Error sending keep alive")?;
+        }
+        {
+            // Now add 1 second and our worker should have been evicted due to timeout.
+            now_timestamp += 1;
+            test_context.scheduler.remove_timedout_workers(now_timestamp).await?;
+            let worker_exists = test_context
+                .scheduler
+                .contains_worker_for_test(&test_context.worker_id)
+                .await;
+            assert!(!worker_exists, "Expected worker to not exist in map");
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    pub async fn worker_receives_keep_alive_request_test() -> Result<(), Box<dyn std::error::Error>> {
+        let mut test_context = setup_api_server(BASE_WORKER_TIMEOUT_S, &static_now_fn).await?;
+
+        // Send keep alive to client.
+        test_context
+            .scheduler
+            .send_keep_alive_to_worker_for_test(&test_context.worker_id)
+            .await
+            .err_tip(|| "Could not send keep alive to worker")?;
+
+        {
+            // Read stream and ensure it was a keep alive message.
+            let maybe_message = test_context.connection_worker_stream.next().await;
+            assert!(maybe_message.is_some(), "Expected next message in stream to exist");
+            let update_message = maybe_message
+                .unwrap()
+                .err_tip(|| "Expected success result")?
+                .update
+                .err_tip(|| "Expected update field to be populated")?;
+            assert_eq!(
+                update_message,
+                update_for_worker::Update::KeepAlive(()),
+                "Expected KeepAlive message"
+            );
+        }
 
         Ok(())
     }

--- a/cas/grpc_service/worker_api_server.rs
+++ b/cas/grpc_service/worker_api_server.rs
@@ -2,7 +2,7 @@
 
 use std::pin::Pin;
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use futures::{stream::unfold, Stream};
 use tokio::sync::mpsc;
@@ -10,26 +10,45 @@ use tonic::{Request, Response, Status};
 use uuid::Uuid;
 
 use common::log;
-use error::{Error, ResultExt};
+use error::{make_err, Code, Error, ResultExt};
 use platform_property_manager::{PlatformProperties, PlatformPropertyManager};
 use proto::com::github::allada::turbo_cache::remote_execution::{
-    worker_api_server::WorkerApi, ExecuteResult, SupportedProperties, UpdateForWorker,
+    worker_api_server::WorkerApi, ExecuteResult, GoingAwayRequest, KeepAliveRequest, SupportedProperties,
+    UpdateForWorker,
 };
 use scheduler::Scheduler;
 use worker::{Worker, WorkerId};
 
-type ConnectWorkerStream = Pin<Box<dyn Stream<Item = Result<UpdateForWorker, Status>> + Send + Sync + 'static>>;
+pub type ConnectWorkerStream = Pin<Box<dyn Stream<Item = Result<UpdateForWorker, Status>> + Send + Sync + 'static>>;
+
+pub type NowFn = dyn Fn() -> Result<Duration, Error> + Send + Sync + 'static;
 
 pub struct WorkerApiServer {
     platform_property_manager: Arc<PlatformPropertyManager>,
     scheduler: Arc<Scheduler>,
+    now_fn: &'static NowFn,
 }
 
 impl WorkerApiServer {
     pub fn new(platform_property_manager: Arc<PlatformPropertyManager>, scheduler: Arc<Scheduler>) -> Self {
+        Self::new_with_now_fn(platform_property_manager, scheduler, &|| {
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map_err(|_| make_err!(Code::Internal, "System time is now behind unix epoch"))
+        })
+    }
+
+    /// Same as new(), but you can pass a custom `now_fn`, that returns a Duration since UNIX_EPOCH
+    /// representing the current time. Used mostly in  unit tests.
+    pub fn new_with_now_fn(
+        platform_property_manager: Arc<PlatformPropertyManager>,
+        scheduler: Arc<Scheduler>,
+        now_fn: &'static NowFn,
+    ) -> Self {
         Self {
             platform_property_manager,
             scheduler,
+            now_fn,
         }
     }
 
@@ -57,7 +76,7 @@ impl WorkerApiServer {
         // Now register the worker with the scheduler.
         let worker_id = {
             let worker_id = Uuid::new_v4().as_u128();
-            let worker = Worker::new(WorkerId(worker_id), platform_properties, tx);
+            let worker = Worker::new(WorkerId(worker_id), platform_properties, tx, (self.now_fn)()?.as_secs());
             self.scheduler
                 .add_worker(worker)
                 .await
@@ -81,6 +100,15 @@ impl WorkerApiServer {
             },
         ))))
     }
+
+    async fn inner_keep_alive(&self, keep_alive_request: KeepAliveRequest) -> Result<Response<()>, Error> {
+        let worker_id: WorkerId = keep_alive_request.worker_id.try_into()?;
+        self.scheduler
+            .worker_keep_alive_received(&worker_id, (self.now_fn)()?.as_secs())
+            .await
+            .err_tip(|| "Could not process keep_alive from worker in inner_keep_alive()")?;
+        Ok(Response::new(()))
+    }
 }
 
 #[tonic::async_trait]
@@ -103,11 +131,21 @@ impl WorkerApi for WorkerApiServer {
         return resp.map_err(|e| e.into());
     }
 
-    async fn keep_alive(&self, _grpc_request: Request<()>) -> Result<Response<()>, Status> {
-        unimplemented!();
+    async fn keep_alive(&self, grpc_request: Request<KeepAliveRequest>) -> Result<Response<()>, Status> {
+        let now = Instant::now();
+        log::info!("\x1b[0;31mkeep_alive Req\x1b[0m: {:?}", grpc_request.get_ref());
+        let keep_alive_request = grpc_request.into_inner();
+        let resp = self.inner_keep_alive(keep_alive_request).await;
+        let d = now.elapsed().as_secs_f32();
+        if let Err(err) = resp.as_ref() {
+            log::error!("\x1b[0;31mkeep_alive Resp\x1b[0m: {} {:?}", d, err);
+        } else {
+            log::info!("\x1b[0;31mkeep_alive Resp\x1b[0m: {}", d);
+        }
+        return resp.map_err(|e| e.into());
     }
 
-    async fn going_away(&self, _grpc_request: Request<()>) -> Result<Response<()>, Status> {
+    async fn going_away(&self, _grpc_request: Request<GoingAwayRequest>) -> Result<Response<()>, Status> {
         unimplemented!();
     }
 

--- a/cas/scheduler/BUILD
+++ b/cas/scheduler/BUILD
@@ -17,6 +17,7 @@ rust_library(
     srcs = ["scheduler.rs"],
     deps = [
         "//third_party:fast_async_mutex",
+        "//third_party:lru",
         "//third_party:rand",
         "//third_party:tokio",
         "//util:common",

--- a/cas/scheduler/worker.rs
+++ b/cas/scheduler/worker.rs
@@ -12,6 +12,8 @@ use proto::com::github::allada::turbo_cache::remote_execution::{
 };
 use tokio::sync::mpsc::UnboundedSender;
 
+pub type WorkerTimestamp = u64;
+
 /// Unique id of worker.
 #[derive(Eq, PartialEq, Hash, Copy, Clone)]
 pub struct WorkerId(pub u128);
@@ -50,6 +52,9 @@ impl TryFrom<String> for WorkerId {
 pub enum WorkerUpdate {
     /// Requests that the worker begin executing this action.
     RunAction(Arc<ActionInfo>),
+
+    /// Request that the worker is no longer in the pool and may discard any jobs.
+    Disconnect,
 }
 
 /// Represents a connection to a worker and used as the medium to
@@ -63,14 +68,29 @@ pub struct Worker {
 
     /// Channel to send commands from scheduler to worker.
     pub tx: UnboundedSender<UpdateForWorker>,
+
+    /// The action info of the running action if worker is assigned one.
+    pub running_action_info: Option<Arc<ActionInfo>>,
+
+    /// Timestamp of last time this worker had been communicated with.
+    // Warning: Do not update this timestamp without updating the placement of the worker in
+    // the LRUCache in the Workers struct.
+    pub last_update_timestamp: WorkerTimestamp,
 }
 
 impl Worker {
-    pub fn new(id: WorkerId, platform_properties: PlatformProperties, tx: UnboundedSender<UpdateForWorker>) -> Self {
+    pub fn new(
+        id: WorkerId,
+        platform_properties: PlatformProperties,
+        tx: UnboundedSender<UpdateForWorker>,
+        timestamp: WorkerTimestamp,
+    ) -> Self {
         Self {
             id,
             platform_properties,
             tx,
+            running_action_info: None,
+            last_update_timestamp: timestamp,
         }
     }
 
@@ -87,7 +107,13 @@ impl Worker {
     pub fn notify_update(&mut self, worker_update: WorkerUpdate) -> Result<(), Error> {
         match worker_update {
             WorkerUpdate::RunAction(action_info) => self.run_action(action_info),
+            WorkerUpdate::Disconnect => self.send_msg_to_worker(update_for_worker::Update::Disconnect(())),
         }
+    }
+
+    pub fn keep_alive(&mut self) -> Result<(), Error> {
+        self.send_msg_to_worker(update_for_worker::Update::KeepAlive(()))
+            .err_tip(|| format!("Failed to send KeepAlive to worker : {}", self.id))
     }
 
     fn send_msg_to_worker(&mut self, msg: update_for_worker::Update) -> Result<(), Error> {
@@ -97,12 +123,16 @@ impl Worker {
     }
 
     fn run_action(&mut self, action_info: Arc<ActionInfo>) -> Result<(), Error> {
+        self.running_action_info = Some(action_info.clone());
         self.reduce_platform_properties(&action_info.platform_properties);
         self.send_msg_to_worker(update_for_worker::Update::StartAction(StartExecute {
-            execute_request: Some(action_info.as_ref().into()),
+            execute_request: Some(self.running_action_info.as_ref().unwrap().as_ref().into()),
         }))
     }
 
+    /// Reduces the platform properties available on the worker based on the platform properties provided.
+    /// This is used because we allow more than 1 job to run on a worker at a time, and this is how the
+    /// scheduler knows if more jobs can run on a given worker.
     fn reduce_platform_properties(&mut self, props: &PlatformProperties) {
         debug_assert!(props.is_satisfied_by(&self.platform_properties));
         for (property, prop_value) in &props.properties {

--- a/config/cas_server.rs
+++ b/config/cas_server.rs
@@ -82,6 +82,12 @@ pub struct ExecutionConfig {
     /// This store name referenced here may be reused multiple times.
     /// This value must be a CAS store reference.
     pub cas_store: StoreRefName,
+
+    /// Remove workers from pool once the worker has not responded in this
+    /// amount of time in seconds.
+    /// Default: 5 (seconds)
+    #[serde(default)]
+    pub worker_timeout_s: u64,
 }
 
 #[derive(Deserialize, Debug)]

--- a/proto/com/github/allada/turbo_cache/remote_execution/worker_api.proto
+++ b/proto/com/github/allada/turbo_cache/remote_execution/worker_api.proto
@@ -25,7 +25,7 @@ service WorkerApi {
     /// may close the connection if the worker has not sent any messages
     /// after some amount of time (configured in the scheduler's
     /// configuration).
-    rpc KeepAlive(google.protobuf.Empty) returns (google.protobuf.Empty);
+    rpc KeepAlive(KeepAliveRequest) returns (google.protobuf.Empty);
 
     /// Informs the scheduler that the service is going offline and
     /// should stop issuing any new actions on this worker.
@@ -38,10 +38,24 @@ service WorkerApi {
     /// Any job that was running on this instance likely needs to be
     /// executed again, but up to the scheduler on how or when to handle
     /// this case.
-    rpc GoingAway(google.protobuf.Empty) returns (google.protobuf.Empty);
+    rpc GoingAway(GoingAwayRequest) returns (google.protobuf.Empty);
 
     /// Informs the scheduler about the result of an execution request.
     rpc ExecutionResponse(ExecuteResult) returns (google.protobuf.Empty);
+}
+
+/// Request object for keep alive requests.
+message KeepAliveRequest {
+    /// ID of the worker making the request.
+    string worker_id = 1;
+    reserved 2; // NextId.
+}
+
+/// Request object for going away requests.
+message GoingAwayRequest {
+    /// ID of the worker making the request.
+    string worker_id = 1;
+    reserved 2; // NextId.
 }
 
 /// Represents the initial request sent to the scheduler informing the
@@ -63,10 +77,11 @@ message SupportedProperties {
 
 /// Represents the result of an execution.
 message ExecuteResult {
+    string worker_id = 1;
     /// Result of the execution. See `build.bazel.remote.execution.v2.ExecuteResponse`
     /// for details.
-    build.bazel.remote.execution.v2.ExecuteResponse execute_response = 1;
-    reserved 2; // NextId.
+    build.bazel.remote.execution.v2.ExecuteResponse execute_response = 2;
+    reserved 3; // NextId.
 }
 
 /// Result sent back from the server when a node connects.
@@ -93,8 +108,12 @@ message UpdateForWorker {
         /// Informs the worker about some work it should begin performing the
         /// requested action.
         StartExecute start_action = 3;
+
+        /// Informs the worker that it has been disconnected from the pool.
+        /// The worker may discard any outstanding work that is being executed.
+        google.protobuf.Empty disconnect = 4;
     }
-    reserved 4; // NextId.
+    reserved 5; // NextId.
 }
 
 message StartExecute {


### PR DESCRIPTION
The scheduler will now support ability to evict workers if they
timeout. The WorkerApiServer will now refresh worker timeouts based
on keep_alive request being sent from the worker. If the worker was
evicted and was executing a job the job will now be rescheduled.