### PR TITLE
Restructure config format in prep for WorkerApiServer

### DIFF
--- a/cas/BUILD
+++ b/cas/BUILD
@@ -12,6 +12,7 @@ rust_binary(
         "//cas/grpc_service:capabilities_server",
         "//cas/grpc_service:cas_server",
         "//cas/grpc_service:execution_server",
+        "//cas/scheduler",
         "//cas/store",
         "//cas/store:default_store_factory",
         "//config",

--- a/cas/grpc_service/BUILD
+++ b/cas/grpc_service/BUILD
@@ -41,6 +41,7 @@ rust_library(
     name = "capabilities_server",
     srcs = ["capabilities_server.rs"],
     deps = [
+        "//cas/scheduler",
         "//cas/store",
         "//config",
         "//proto",
@@ -128,6 +129,7 @@ rust_test(
         "//cas/scheduler",
         "//cas/scheduler:platform_property_manager",
         "//cas/scheduler:worker",
+        "//config",
         "//proto",
         "//third_party:pretty_assertions",
         "//third_party:tokio",

--- a/cas/grpc_service/tests/worker_api_server_test.rs
+++ b/cas/grpc_service/tests/worker_api_server_test.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 use tokio_stream::StreamExt;
 use tonic::Request;
 
+use config::cas_server::SchedulerConfig;
 use error::{Error, ResultExt};
 use platform_property_manager::PlatformPropertyManager;
 use proto::com::github::allada::turbo_cache::remote_execution::{
@@ -32,7 +33,10 @@ fn static_now_fn() -> Result<Duration, Error> {
 
 async fn setup_api_server(worker_timeout: u64, now_fn: NowFn) -> Result<TestContext, Error> {
     let platform_properties = HashMap::new();
-    let scheduler = Arc::new(Scheduler::new(worker_timeout));
+    let scheduler = Arc::new(Scheduler::new(&SchedulerConfig {
+        worker_timeout_s: worker_timeout,
+        ..Default::default()
+    }));
     let worker_api_server = WorkerApiServer::new_with_now_fn(
         Arc::new(PlatformPropertyManager::new(platform_properties)),
         scheduler.clone(),

--- a/cas/scheduler/BUILD
+++ b/cas/scheduler/BUILD
@@ -16,6 +16,7 @@ rust_library(
     name = "scheduler",
     srcs = ["scheduler.rs"],
     deps = [
+        "//config",
         "//third_party:fast_async_mutex",
         "//third_party:lru",
         "//third_party:rand",
@@ -23,6 +24,7 @@ rust_library(
         "//util:common",
         "//util:error",
         ":action_messages",
+        ":platform_property_manager",
         ":worker",
     ],
     visibility = ["//cas:__pkg__", "//cas:__subpackages__"]
@@ -60,6 +62,7 @@ rust_test(
     name = "scheduler_test",
     srcs = ["tests/scheduler_test.rs"],
     deps = [
+        "//config",
         "//proto",
         "//third_party:pretty_assertions",
         "//third_party:tokio",

--- a/cas/scheduler/platform_property_manager.rs
+++ b/cas/scheduler/platform_property_manager.rs
@@ -85,6 +85,11 @@ impl PlatformPropertyManager {
         Self { known_properties }
     }
 
+    /// Returns the `known_properties` map.
+    pub fn get_known_properties(&self) -> &HashMap<String, PropertyType> {
+        &self.known_properties
+    }
+
     /// Given a specific key and value, returns the translated `PlatformPropertyValue`. This will
     /// automatically convert any strings to the type-value pairs of `PlatformPropertyValue` based
     /// on the configuration passed into the `PlatformPropertyManager` constructor.

--- a/cas/scheduler/tests/scheduler_test.rs
+++ b/cas/scheduler/tests/scheduler_test.rs
@@ -7,6 +7,7 @@ use tokio::sync::mpsc;
 
 use action_messages::{ActionInfo, ActionStage, ActionState};
 use common::DigestInfo;
+use config::cas_server::SchedulerConfig;
 use error::{Error, ResultExt};
 use platform_property_manager::{PlatformProperties, PlatformPropertyValue};
 use proto::build::bazel::remote::execution::v2::ExecuteRequest;
@@ -58,7 +59,7 @@ mod scheduler_tests {
     async fn basic_add_action_with_one_worker_test() -> Result<(), Error> {
         const WORKER_ID: WorkerId = WorkerId(0x123456789111);
 
-        let scheduler = Scheduler::new(BASE_WORKER_TIMEOUT_S);
+        let scheduler = Scheduler::new(&SchedulerConfig::default());
         let action_digest = DigestInfo::new([99u8; 32], 512);
 
         let mut rx_from_worker = {
@@ -109,7 +110,7 @@ mod scheduler_tests {
 
     #[tokio::test]
     async fn worker_should_not_queue_if_properties_dont_match_test() -> Result<(), Error> {
-        let scheduler = Scheduler::new(BASE_WORKER_TIMEOUT_S);
+        let scheduler = Scheduler::new(&SchedulerConfig::default());
         let action_digest = DigestInfo::new([99u8; 32], 512);
         let mut platform_properties = PlatformProperties::default();
         platform_properties
@@ -197,7 +198,7 @@ mod scheduler_tests {
     async fn cacheable_items_join_same_action_queued_test() -> Result<(), Error> {
         const WORKER_ID: WorkerId = WorkerId(0x100009);
 
-        let scheduler = Scheduler::new(BASE_WORKER_TIMEOUT_S);
+        let scheduler = Scheduler::new(&SchedulerConfig::default());
         let action_digest = DigestInfo::new([99u8; 32], 512);
 
         let mut expected_action_state = ActionState {
@@ -278,7 +279,7 @@ mod scheduler_tests {
     #[tokio::test]
     async fn worker_disconnects_does_not_schedule_for_execution_test() -> Result<(), Error> {
         const WORKER_ID: WorkerId = WorkerId(0x100010);
-        let scheduler = Scheduler::new(BASE_WORKER_TIMEOUT_S);
+        let scheduler = Scheduler::new(&SchedulerConfig::default());
         let action_digest = DigestInfo::new([99u8; 32], 512);
         let platform_properties = PlatformProperties::default();
 
@@ -318,7 +319,10 @@ mod scheduler_tests {
     async fn worker_timesout_reschedules_running_job_test() -> Result<(), Error> {
         const WORKER_ID1: WorkerId = WorkerId(0x111111);
         const WORKER_ID2: WorkerId = WorkerId(0x222222);
-        let scheduler = Scheduler::new(BASE_WORKER_TIMEOUT_S);
+        let scheduler = Scheduler::new(&SchedulerConfig {
+            worker_timeout_s: BASE_WORKER_TIMEOUT_S,
+            ..Default::default()
+        });
         let action_digest = DigestInfo::new([99u8; 32], 512);
         let platform_properties = PlatformProperties::default();
 

--- a/config/README.md
+++ b/config/README.md
@@ -47,7 +47,6 @@ A very basic configuration that is a pure in-memory store is:
       "capabilities": {
         "main": {}
       },
-      "execution": {},
       "bytestream": {
         "cas_stores": {
           "main": "CAS_MAIN_STORE",

--- a/config/examples/basic_cas.json
+++ b/config/examples/basic_cas.json
@@ -17,6 +17,27 @@
       }
     }
   },
+  "schedulers": {
+    "MAIN_SCHEDULER": {
+      "supported_platform_properties": {
+        "cpu_count": "Minimum",
+        "memory_kb": "Minimum",
+        "network_kbps": "Minimum",
+        "disk_read_iops": "Minimum",
+        "disk_read_bps": "Minimum",
+        "disk_write_iops": "Minimum",
+        "disk_write_bps": "Minimum",
+        "shm_size": "Minimum",
+        "gpu_count": "Minimum",
+        "gpu_model": "Exact",
+        "cpu_vendor": "Exact",
+        "cpu_arch": "Exact",
+        "cpu_model": "Exact",
+        "kernel_version": "Exact",
+        "docker_image": "Metadata",
+      }
+    }
+  },
   "servers": [{
     "listen_address": "0.0.0.0:50051",
     "services": {
@@ -33,26 +54,13 @@
       "execution": {
         "main": {
           "cas_store": "CAS_MAIN_STORE",
+          "scheduler": "MAIN_SCHEDULER",
         }
       },
       "capabilities": {
         "main": {
-          "supported_platform_properties": {
-            "cpu_count": "Minimum",
-            "memory_kb": "Minimum",
-            "network_kbps": "Minimum",
-            "disk_read_iops": "Minimum",
-            "disk_read_bps": "Minimum",
-            "disk_write_iops": "Minimum",
-            "disk_write_bps": "Minimum",
-            "shm_size": "Minimum",
-            "gpu_count": "Minimum",
-            "gpu_model": "Exact",
-            "cpu_vendor": "Exact",
-            "cpu_arch": "Exact",
-            "cpu_model": "Exact",
-            "kernel_version": "Exact",
-            "docker_image": "Metadata",
+          "remote_execution": {
+            "scheduler": "MAIN_SCHEDULER",
           }
         }
       },

--- a/config/examples/filesystem_cas.json
+++ b/config/examples/filesystem_cas.json
@@ -103,31 +103,8 @@
           "ac_store": "AC_MAIN_STORE"
         }
       },
-      "execution": {
-        "main": {
-          "cas_store": "CAS_MAIN_STORE",
-        }
-      },
       "capabilities": {
-        "main": {
-          "supported_platform_properties": {
-            "cpu_count": "Minimum",
-            "memory_kb": "Minimum",
-            "network_kbps": "Minimum",
-            "disk_read_iops": "Minimum",
-            "disk_read_bps": "Minimum",
-            "disk_write_iops": "Minimum",
-            "disk_write_bps": "Minimum",
-            "shm_size": "Minimum",
-            "gpu_count": "Minimum",
-            "gpu_model": "Exact",
-            "cpu_vendor": "Exact",
-            "cpu_arch": "Exact",
-            "cpu_model": "Exact",
-            "kernel_version": "Exact",
-            "docker_image": "Metadata",
-          }
-        }
+        "main": {},
       },
       "bytestream": {
         "cas_stores": {

--- a/config/examples/s3_backend_with_local_fast_cas.json
+++ b/config/examples/s3_backend_with_local_fast_cas.json
@@ -105,6 +105,27 @@
       }
     }
   },
+  "schedulers": {
+    "MAIN_SCHEDULER": {
+      "supported_platform_properties": {
+        "cpu_count": "Minimum",
+        "memory_kb": "Minimum",
+        "network_kbps": "Minimum",
+        "disk_read_iops": "Minimum",
+        "disk_read_bps": "Minimum",
+        "disk_write_iops": "Minimum",
+        "disk_write_bps": "Minimum",
+        "shm_size": "Minimum",
+        "gpu_count": "Minimum",
+        "gpu_model": "Exact",
+        "cpu_vendor": "Exact",
+        "cpu_arch": "Exact",
+        "cpu_model": "Exact",
+        "kernel_version": "Exact",
+        "docker_image": "Metadata",
+      }
+    }
+  },
   "servers": [{
     "listen_address": "0.0.0.0:50051",
     "services": {
@@ -121,26 +142,13 @@
       "execution": {
         "main": {
           "cas_store": "CAS_MAIN_STORE",
+          "scheduler": "MAIN_SCHEDULER",
         }
       },
       "capabilities": {
         "main": {
-          "supported_platform_properties": {
-            "cpu_count": "Minimum",
-            "memory_kb": "Minimum",
-            "network_kbps": "Minimum",
-            "disk_read_iops": "Minimum",
-            "disk_read_bps": "Minimum",
-            "disk_write_iops": "Minimum",
-            "disk_write_bps": "Minimum",
-            "shm_size": "Minimum",
-            "gpu_count": "Minimum",
-            "gpu_model": "Exact",
-            "cpu_vendor": "Exact",
-            "cpu_arch": "Exact",
-            "cpu_model": "Exact",
-            "kernel_version": "Exact",
-            "docker_image": "Metadata",
+          "remote_execution": {
+            "scheduler": "MAIN_SCHEDULER",
           }
         }
       },


### PR DESCRIPTION
Restructure the format of how scheduler and platform properties
are in the config spec. This will allow more intuitive sharing
of scheduler and platform properties to different services.

* `schedulers` is now a root-level map and services reference the
  name of that scheduler instead of defined inline.
* Platform properties are now owned by the scheduler.
* Updated example config files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/allada/turbo-cache/51)
<!-- Reviewable:end -->
