### PR TITLE
Add WorkerApiServer to services being served

### DIFF
--- a/cas/BUILD
+++ b/cas/BUILD
@@ -12,6 +12,7 @@ rust_binary(
         "//cas/grpc_service:capabilities_server",
         "//cas/grpc_service:cas_server",
         "//cas/grpc_service:execution_server",
+        "//cas/grpc_service:worker_api_server",
         "//cas/scheduler",
         "//cas/store",
         "//cas/store:default_store_factory",

--- a/cas/grpc_service/BUILD
+++ b/cas/grpc_service/BUILD
@@ -99,6 +99,7 @@ rust_library(
         "//cas/scheduler",
         "//cas/scheduler:platform_property_manager",
         "//cas/scheduler:worker",
+        "//config",
         "//proto",
         "//third_party:futures",
         "//third_party:tokio",
@@ -127,7 +128,6 @@ rust_test(
     srcs = ["tests/worker_api_server_test.rs"],
     deps = [
         "//cas/scheduler",
-        "//cas/scheduler:platform_property_manager",
         "//cas/scheduler:worker",
         "//config",
         "//proto",

--- a/config/cas_server.rs
+++ b/config/cas_server.rs
@@ -121,6 +121,12 @@ pub struct ByteStreamConfig {
 }
 
 #[derive(Deserialize, Debug)]
+pub struct WorkerApiConfig {
+    /// The scheduler name referenced in the `schedulers` map in the main config.
+    pub scheduler: SchedulerRefName,
+}
+
+#[derive(Deserialize, Debug)]
 pub struct ServicesConfig {
     /// The Content Addressable Storage (CAS) backend config.
     /// The key is the instance_name used in the protocol and the
@@ -146,6 +152,15 @@ pub struct ServicesConfig {
     /// Bazel's protocol strongly encourages users to use this streaming
     /// interface to interact with the CAS when the data is large.
     pub bytestream: Option<ByteStreamConfig>,
+
+    /// This is the service used for workers to connect and communicate
+    /// through.
+    /// NOTE: This service should be served on a different, non-public port.
+    /// In other words, `worker_api` configuration should not have any other
+    /// services that are served on the same port. Doing so is a security
+    /// risk, as workers have a different permission set than a client
+    /// that makes the remote execution/cache requests.
+    pub worker_api: Option<WorkerApiConfig>,
 }
 
 #[derive(Deserialize, Debug)]

--- a/config/examples/basic_cas.json
+++ b/config/examples/basic_cas.json
@@ -72,5 +72,16 @@
         "max_bytes_per_stream": 64000, // 64kb.
       }
     }
+  }, {
+    "listen_address": "0.0.0.0:50061",
+    "services": {
+      // Note: This should be served on a different port, because it has
+      // a different permission set than the other services.
+      // In other words, this service is a backend api. The ones above
+      // are a frontend api.
+      "worker_api": {
+        "scheduler": "MAIN_SCHEDULER",
+      }
+    }
   }]
 }

--- a/config/examples/filesystem_cas.json
+++ b/config/examples/filesystem_cas.json
@@ -90,6 +90,27 @@
       }
     }
   },
+  "schedulers": {
+    "MAIN_SCHEDULER": {
+      "supported_platform_properties": {
+        "cpu_count": "Minimum",
+        "memory_kb": "Minimum",
+        "network_kbps": "Minimum",
+        "disk_read_iops": "Minimum",
+        "disk_read_bps": "Minimum",
+        "disk_write_iops": "Minimum",
+        "disk_write_bps": "Minimum",
+        "shm_size": "Minimum",
+        "gpu_count": "Minimum",
+        "gpu_model": "Exact",
+        "cpu_vendor": "Exact",
+        "cpu_arch": "Exact",
+        "cpu_model": "Exact",
+        "kernel_version": "Exact",
+        "docker_image": "Metadata",
+      }
+    }
+  },
   "servers": [{
     "listen_address": "0.0.0.0:50051",
     "services": {
@@ -103,8 +124,18 @@
           "ac_store": "AC_MAIN_STORE"
         }
       },
+      "execution": {
+        "main": {
+          "cas_store": "CAS_MAIN_STORE",
+          "scheduler": "MAIN_SCHEDULER",
+        }
+      },
       "capabilities": {
-        "main": {},
+        "main": {
+          "remote_execution": {
+            "scheduler": "MAIN_SCHEDULER",
+          }
+        }
       },
       "bytestream": {
         "cas_stores": {
@@ -112,6 +143,17 @@
         },
         // According to https://github.com/grpc/grpc.github.io/issues/371 16KiB - 64KiB is optimal.
         "max_bytes_per_stream": 64000, // 64kb.
+      }
+    }
+  }, {
+    "listen_address": "0.0.0.0:50061",
+    "services": {
+      // Note: This should be served on a different port, because it has
+      // a different permission set than the other services.
+      // In other words, this service is a backend api. The ones above
+      // are a frontend api.
+      "worker_api": {
+        "scheduler": "MAIN_SCHEDULER",
       }
     }
   }]


### PR DESCRIPTION
Adds WorkerApiServer so it can now be served over the GRPC
connections based on config file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/allada/turbo-cache/52)
<!-- Reviewable:end -->
