### PR TITLE
Implement going_away() support to WorkerAPIServer

### DIFF
--- a/cas/grpc_service/tests/worker_api_server_test.rs
+++ b/cas/grpc_service/tests/worker_api_server_test.rs
@@ -209,3 +209,29 @@ pub mod keep_alive_tests {
         Ok(())
     }
 }
+
+#[cfg(test)]
+pub mod going_away_tests {
+    use super::*;
+
+    #[tokio::test]
+    pub async fn going_away_removes_worker() -> Result<(), Box<dyn std::error::Error>> {
+        let test_context = setup_api_server(BASE_WORKER_TIMEOUT_S, Box::new(static_now_fn)).await?;
+
+        let worker_exists = test_context
+            .scheduler
+            .contains_worker_for_test(&test_context.worker_id)
+            .await;
+        assert!(worker_exists, "Expected worker to exist in worker map");
+
+        test_context.scheduler.remove_worker(test_context.worker_id).await;
+
+        let worker_exists = test_context
+            .scheduler
+            .contains_worker_for_test(&test_context.worker_id)
+            .await;
+        assert!(!worker_exists, "Expected worker to be removed from worker map");
+
+        Ok(())
+    }
+}

--- a/cas/scheduler/scheduler.rs
+++ b/cas/scheduler/scheduler.rs
@@ -370,6 +370,13 @@ impl Scheduler {
             .err_tip(|| "Error refreshing lifetime in worker_keep_alive_received()")
     }
 
+    /// Removes worker from pool and reschedule any tasks that might be running on it.
+    pub async fn remove_worker(&self, worker_id: WorkerId) {
+        let mut inner = self.inner.lock().await;
+        inner.immediate_evict_worker(&worker_id);
+        inner.do_try_match();
+    }
+
     pub async fn remove_timedout_workers(&self, now_timestamp: WorkerTimestamp) -> Result<(), Error> {
         let mut inner = self.inner.lock().await;
         // Items should be sorted based on last_update_timestamp, so we don't need to iterate the entire


### PR DESCRIPTION
Implements the ability for the worker to notify the server that
it is shutting down and reschedule any jobs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/allada/turbo-cache/53)
<!-- Reviewable:end -->
