### PR TITLE
Implement execution_response() in WorkerApiServer

### DIFF
--- a/cas/grpc_service/BUILD
+++ b/cas/grpc_service/BUILD
@@ -97,6 +97,7 @@ rust_library(
     srcs = ["worker_api_server.rs"],
     deps = [
         "//cas/scheduler",
+        "//cas/scheduler:action_messages",
         "//cas/scheduler:platform_property_manager",
         "//cas/scheduler:worker",
         "//config",
@@ -128,6 +129,8 @@ rust_test(
     srcs = ["tests/worker_api_server_test.rs"],
     deps = [
         "//cas/scheduler",
+        "//cas/scheduler:action_messages",
+        "//cas/scheduler:platform_property_manager",
         "//cas/scheduler:worker",
         "//config",
         "//proto",
@@ -135,6 +138,7 @@ rust_test(
         "//third_party:tokio",
         "//third_party:tokio_stream",
         "//third_party:tonic",
+        "//util:common",
         "//util:error",
         ":worker_api_server",
     ],

--- a/cas/grpc_service/execution_server.rs
+++ b/cas/grpc_service/execution_server.rs
@@ -12,7 +12,7 @@ use tokio_stream::wrappers::WatchStream;
 use tonic::{Request, Response, Status};
 
 use ac_utils::get_and_decode_digest;
-use action_messages::ActionInfo;
+use action_messages::{ActionInfo, ActionInfoHashKey};
 use common::{log, DigestInfo};
 use config::cas_server::{ExecutionConfig, InstanceName};
 use error::{make_input_err, Error, ResultExt};
@@ -79,17 +79,19 @@ impl InstanceInfo {
 
         Ok(ActionInfo {
             instance_name,
-            digest: action_digest,
             command_digest,
             input_root_digest,
             timeout,
             platform_properties: PlatformProperties::new(platform_properties),
             priority,
             insert_timestamp: SystemTime::now(),
-            salt: if action.do_not_cache {
-                thread_rng().gen::<u64>()
-            } else {
-                0
+            unique_qualifier: ActionInfoHashKey {
+                digest: action_digest,
+                salt: if action.do_not_cache {
+                    thread_rng().gen::<u64>()
+                } else {
+                    0
+                },
             },
         })
     }

--- a/cas/grpc_service/tests/cas_server_test.rs
+++ b/cas/grpc_service/tests/cas_server_test.rs
@@ -287,10 +287,7 @@ mod batch_read_blobs {
                             data: vec![].into(),
                             status: Some(GrpcStatus {
                                 code: Code::NotFound as i32,
-                                message: format!(
-                                    "Error: Error {{ code: NotFound, messages: [\"Hash {} not found\"] }}",
-                                    digest3.hash
-                                ),
+                                message: format!("Hash {} not found", digest3.hash),
                                 details: vec![],
                             }),
                         }

--- a/cas/scheduler/BUILD
+++ b/cas/scheduler/BUILD
@@ -51,6 +51,7 @@ rust_library(
         "//proto",
         "//third_party:prost",
         "//third_party:prost_types",
+        "//third_party:tonic",
         "//util:common",
         "//util:error",
         ":platform_property_manager",

--- a/cas/scheduler/worker.rs
+++ b/cas/scheduler/worker.rs
@@ -127,6 +127,7 @@ impl Worker {
         self.reduce_platform_properties(&action_info.platform_properties);
         self.send_msg_to_worker(update_for_worker::Update::StartAction(StartExecute {
             execute_request: Some(self.running_action_info.as_ref().unwrap().as_ref().into()),
+            salt: *action_info.salt(),
         }))
     }
 

--- a/proto/com/github/allada/turbo_cache/remote_execution/worker_api.proto
+++ b/proto/com/github/allada/turbo_cache/remote_execution/worker_api.proto
@@ -77,11 +77,23 @@ message SupportedProperties {
 
 /// Represents the result of an execution.
 message ExecuteResult {
+    /// ID of the worker making the request.
     string worker_id = 1;
+
+    /// The original execution digest request for this response. The scheduler knows what it
+    /// should be, but we do safety checks to ensure it really is the request we expected.
+    build.bazel.remote.execution.v2.Digest action_digest = 2;
+
+    /// The salt originally sent along with the StartExecute request. This salt is used
+    /// as a seed for cases where the execution digest should never be cached or merged
+    /// with other jobs. This salt is added to the hash function used to compute jobs that
+    /// are running or cached.
+    uint64 salt = 3;
+
     /// Result of the execution. See `build.bazel.remote.execution.v2.ExecuteResponse`
     /// for details.
-    build.bazel.remote.execution.v2.ExecuteResponse execute_response = 2;
-    reserved 3; // NextId.
+    build.bazel.remote.execution.v2.ExecuteResponse execute_response = 4;
+    reserved 5; // NextId.
 }
 
 /// Result sent back from the server when a node connects.
@@ -117,6 +129,10 @@ message UpdateForWorker {
 }
 
 message StartExecute {
+    /// The action information used to execute job.
     build.bazel.remote.execution.v2.ExecuteRequest execute_request = 1;
-    reserved 2; // NextId.
+
+    /// See documentation in ExecuteResult::salt.
+    uint64 salt = 2;
+    reserved 3; // NextId.
 }

--- a/proto/genproto/com.github.allada.turbo_cache.remote_execution.pb.rs
+++ b/proto/genproto/com.github.allada.turbo_cache.remote_execution.pb.rs
@@ -35,11 +35,24 @@ pub struct SupportedProperties {
 //// Represents the result of an execution.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExecuteResult {
+    //// ID of the worker making the request.
     #[prost(string, tag = "1")]
     pub worker_id: ::prost::alloc::string::String,
+    //// The original execution digest request for this response. The scheduler knows what it
+    //// should be, but we do safety checks to ensure it really is the request we expected.
+    #[prost(message, optional, tag = "2")]
+    pub action_digest: ::core::option::Option<
+        super::super::super::super::super::build::bazel::remote::execution::v2::Digest,
+    >,
+    //// The salt originally sent along with the StartExecute request. This salt is used
+    //// as a seed for cases where the execution digest should never be cached or merged
+    //// with other jobs. This salt is added to the hash function used to compute jobs that
+    //// are running or cached.
+    #[prost(uint64, tag = "3")]
+    pub salt: u64,
     //// Result of the execution. See `build.bazel.remote.execution.v2.ExecuteResponse`
     //// for details.
-    #[prost(message, optional, tag = "2")]
+    #[prost(message, optional, tag = "4")]
     pub execute_response: ::core::option::Option<
         super::super::super::super::super::build::bazel::remote::execution::v2::ExecuteResponse,
     >,
@@ -84,10 +97,14 @@ pub mod update_for_worker {
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct StartExecute {
+    //// The action information used to execute job.
     #[prost(message, optional, tag = "1")]
     pub execute_request: ::core::option::Option<
         super::super::super::super::super::build::bazel::remote::execution::v2::ExecuteRequest,
     >,
+    //// See documentation in ExecuteResult::salt.
+    #[prost(uint64, tag = "2")]
+    pub salt: u64,
 }
 #[doc = r" Generated client implementations."]
 pub mod worker_api_client {

--- a/util/BUILD
+++ b/util/BUILD
@@ -9,6 +9,7 @@ rust_library(
         "//proto",
         "//third_party:hex",
         "//third_party:prost",
+        "//third_party:prost_types",
         "//third_party:tokio",
         "//third_party:tonic",
     ],


### PR DESCRIPTION
Implements the execution_response() function. This will allow
workers to let the scheduler and thus the client know a job has
an updated state (usually completed or errord).

This required a few API changes, but nothing dramatic.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/allada/turbo-cache/54)
<!-- Reviewable:end -->
