### PR TITLE
Add worker config definitions and rename Metadata to Priority

### DIFF
--- a/cas/scheduler/platform_property_manager.rs
+++ b/cas/scheduler/platform_property_manager.rs
@@ -43,14 +43,17 @@ impl PlatformProperties {
 /// Minimum  - Means that workers must have at least this number available. When
 ///            a worker executes a task that has this value, the worker will have
 ///            this value subtracted from the available resources of the worker.
-/// Metadata - Means the worker is given this information, but does not restrict
+/// Priority - Means the worker is given this information, but does not restrict
 ///            what workers can take this value. However, the worker must have the
 ///            associated key present to be matched.
+///            TODO(allada) In the future this will be used by the scheduler and
+///            worker to cause the scheduler to prefer certain workers over others,
+///            but not restrict them based on these values.
 #[derive(Eq, PartialEq, Hash, Clone, Ord, PartialOrd, Debug)]
 pub enum PlatformPropertyValue {
     Exact(String),
     Minimum(u64),
-    Metadata(String),
+    Priority(String),
 }
 
 impl PlatformPropertyValue {
@@ -66,9 +69,10 @@ impl PlatformPropertyValue {
                 }
                 false
             }
-            // Metadata is used to pass info to the worker and not restrict which
-            // workers can be selected.
-            PlatformPropertyValue::Metadata(_) => true,
+            // Priority is used to pass info to the worker and not restrict which
+            // workers can be selected, but might be used to prefer certain workers
+            // over others.
+            PlatformPropertyValue::Priority(_) => true,
             // Success exact case is handled above.
             PlatformPropertyValue::Exact(_) => false,
         }
@@ -105,7 +109,7 @@ impl PlatformPropertyManager {
                     })?,
                 )),
                 PropertyType::Exact => Ok(PlatformPropertyValue::Exact(value.to_string())),
-                PropertyType::Metadata => Ok(PlatformPropertyValue::Metadata(value.to_string())),
+                PropertyType::Priority => Ok(PlatformPropertyValue::Priority(value.to_string())),
             };
         }
         Err(make_input_err!("Unknown platform property '{}'", key))

--- a/config/examples/basic_cas.json
+++ b/config/examples/basic_cas.json
@@ -15,6 +15,16 @@
           "max_bytes": 10000000,
         }
       }
+    },
+    "WORKER_FILESYSTEM_STORE": {
+      "filesystem": {
+        "content_path": "/tmp/turbo_cache/data/content_path-cas",
+        "temp_path": "/tmp/turbo_cache/data/tmp_path-cas",
+        "eviction_policy": {
+          // 2gb.
+          "max_bytes": 2000000000,
+        }
+      }
     }
   },
   "schedulers": {
@@ -34,10 +44,37 @@
         "cpu_arch": "Exact",
         "cpu_model": "Exact",
         "kernel_version": "Exact",
-        "docker_image": "Metadata",
+        "docker_image": "Priority",
       }
     }
   },
+  "workers": [{
+    "local": {
+      "worker_api_endpoint": "127.0.0.1:50061",
+      "entrypoint_cmd": "./examples/worker/local_entrypoint.sh $@",
+      "local_filesystem_store_ref": "WORKER_FILESYSTEM_STORE",
+      "cas_store": "CAS_MAIN_STORE",
+      "ac_store": "AC_MAIN_STORE",
+      "work_directory": "/tmp/turbo_cache/work",
+      "platform_properties": {
+        "cpu_count": {
+          "values": ["1"],
+        },
+        "memory_kb": {
+          "values": ["500000"],
+        },
+        "network_kbps": {
+          "values": ["100000"],
+        },
+        "cpu_arch": {
+          "values": ["x86_64"],
+        },
+        "docker_image": {
+          "query_cmd": "docker images --format {{.Repository}}:{{.Tag}}",
+        }
+      }
+    }
+  }],
   "servers": [{
     "listen_address": "0.0.0.0:50051",
     "services": {

--- a/config/examples/filesystem_cas.json
+++ b/config/examples/filesystem_cas.json
@@ -1,5 +1,5 @@
 // This configuration will place objects in various folders in
-// `/tmp/turbo_cache_data`. It will store all data on disk and
+// `/tmp/turbo_cache/data`. It will store all data on disk and
 // allows for restarts of the underlying service. It is optimized
 // so objects are compressed, deduplicated and uses some in-memory
 // optimizations for certain hot paths.
@@ -12,8 +12,8 @@
         },
         "backend": {
           "filesystem": {
-            "content_path": "/tmp/turbo_cache_data/content_path-cas",
-            "temp_path": "/tmp/turbo_cache_data/tmp_path-cas",
+            "content_path": "/tmp/turbo_cache/data/content_path-cas",
+            "temp_path": "/tmp/turbo_cache/data/tmp_path-cas",
             "eviction_policy": {
               // 2gb.
               "max_bytes": 2000000000,
@@ -56,8 +56,8 @@
                     },
                     "slow": {
                       "filesystem": {
-                        "content_path": "/tmp/turbo_cache_data/content_path-index",
-                        "temp_path": "/tmp/turbo_cache_data/tmp_path-index",
+                        "content_path": "/tmp/turbo_cache/data/content_path-index",
+                        "temp_path": "/tmp/turbo_cache/data/tmp_path-index",
                         "eviction_policy": {
                           // 500mb.
                           "max_bytes": 500000000,
@@ -81,8 +81,8 @@
     },
     "AC_MAIN_STORE": {
       "filesystem": {
-        "content_path": "/tmp/turbo_cache_data/content_path-ac",
-        "temp_path": "/tmp/turbo_cache_data/tmp_path-ac",
+        "content_path": "/tmp/turbo_cache/data/content_path-ac",
+        "temp_path": "/tmp/turbo_cache/data/tmp_path-ac",
         "eviction_policy": {
           // 500mb.
           "max_bytes": 500000000,
@@ -107,7 +107,7 @@
         "cpu_arch": "Exact",
         "cpu_model": "Exact",
         "kernel_version": "Exact",
-        "docker_image": "Metadata",
+        "docker_image": "Priority",
       }
     }
   },

--- a/config/examples/s3_backend_with_local_fast_cas.json
+++ b/config/examples/s3_backend_with_local_fast_cas.json
@@ -8,8 +8,8 @@
               "fast_slow": {
                 "fast": {
                   "filesystem": {
-                    "content_path": "/tmp/turbo_cache_data/content_path-index",
-                    "temp_path": "/tmp/turbo_cache_data/tmp_path-index",
+                    "content_path": "/tmp/turbo_cache/data/content_path-index",
+                    "temp_path": "/tmp/turbo_cache/data/tmp_path-index",
                     "eviction_policy": {
                       // 500mb.
                       "max_bytes": 500000000,
@@ -40,8 +40,8 @@
                   "fast_slow": {
                     "fast": {
                       "filesystem": {
-                        "content_path": "/tmp/turbo_cache_data/content_path-content",
-                        "temp_path": "/tmp/turbo_cache_data/tmp_path-content",
+                        "content_path": "/tmp/turbo_cache/data/content_path-content",
+                        "temp_path": "/tmp/turbo_cache/data/tmp_path-content",
                         "eviction_policy": {
                           // 2gb.
                           "max_bytes": 2000000000,
@@ -81,8 +81,8 @@
             }
           },
           "filesystem": {
-            "content_path": "/tmp/turbo_cache_data/content_path-ac",
-            "temp_path": "/tmp/turbo_cache_data/tmp_path-ac",
+            "content_path": "/tmp/turbo_cache/data/content_path-ac",
+            "temp_path": "/tmp/turbo_cache/data/tmp_path-ac",
             "eviction_policy": {
               // 500mb.
               "max_bytes": 500000000,
@@ -122,7 +122,7 @@
         "cpu_arch": "Exact",
         "cpu_model": "Exact",
         "kernel_version": "Exact",
-        "docker_image": "Metadata",
+        "docker_image": "Priority",
       }
     }
   },


### PR DESCRIPTION
* Adds the initial config for workers to use use
* Rename PropertyType::Metadata to PropertyType::Priority

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/allada/turbo-cache/55)
<!-- Reviewable:end -->
