### PR TITLE
Fix github CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Turbo Cache
 
-[![CI](https://github.com/allada/turbo-cache/actions/workflows/main.yml/badge.svg)](https://github.com/allada/turbo-cache/actions/workflows/main.yml)
+[![CI](https://github.com/allada/turbo-cache/workflows/CI/badge.svg)](https://github.com/allada/turbo-cache/actions/workflows/main.yml)
 
 An extremely fast and efficient bazel cache service (CAS) written in rust.
 


### PR DESCRIPTION
Fixes the URL used to show the CI badge on the Readme.md file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/allada/turbo-cache/58)
<!-- Reviewable:end -->
