### PR TITLE
Fix bug in memory store when receiving a zero byte object

### DIFF
--- a/cas/store/memory_store.rs
+++ b/cas/store/memory_store.rs
@@ -98,10 +98,12 @@ impl StoreTrait for MemoryStore {
 
         let default_len = value.len() - offset;
         let length = length.unwrap_or(default_len).min(default_len);
-        writer
-            .send(value.0.slice(offset..(offset + length)))
-            .await
-            .err_tip(|| "Failed to write data in memory store")?;
+        if length > 0 {
+            writer
+                .send(value.0.slice(offset..(offset + length)))
+                .await
+                .err_tip(|| "Failed to write data in memory store")?;
+        }
         writer
             .send_eof()
             .await


### PR DESCRIPTION
An edge case was discovered in another unit test where a zero
byte object (empty file) would error out during receive.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/allada/turbo-cache/64)
<!-- Reviewable:end -->
