### PR TITLE
Adds .as_any() to stores

### DIFF
--- a/cas/store/compression_store.rs
+++ b/cas/store/compression_store.rs
@@ -559,4 +559,8 @@ impl StoreTrait for CompressionStore {
         }
         Ok(())
     }
+
+    fn as_any(self: Arc<Self>) -> Arc<dyn std::any::Any> {
+        self
+    }
 }

--- a/cas/store/dedup_store.rs
+++ b/cas/store/dedup_store.rs
@@ -324,4 +324,8 @@ impl StoreTrait for DedupStore {
             .err_tip(|| "Failed to write EOF out from get_part dedup")?;
         Ok(())
     }
+
+    fn as_any(self: Arc<Self>) -> Arc<dyn std::any::Any> {
+        self
+    }
 }

--- a/cas/store/fast_slow_store.rs
+++ b/cas/store/fast_slow_store.rs
@@ -181,4 +181,8 @@ impl StoreTrait for FastSlowStore {
         data_stream_res.merge(fast_res).merge(slow_res)?;
         Ok(())
     }
+
+    fn as_any(self: Arc<Self>) -> Arc<dyn std::any::Any> {
+        self
+    }
 }

--- a/cas/store/filesystem_store.rs
+++ b/cas/store/filesystem_store.rs
@@ -431,4 +431,8 @@ impl StoreTrait for FilesystemStore {
 
         Ok(())
     }
+
+    fn as_any(self: Arc<Self>) -> Arc<dyn std::any::Any> {
+        self
+    }
 }

--- a/cas/store/memory_store.rs
+++ b/cas/store/memory_store.rs
@@ -2,6 +2,7 @@
 
 use std::fmt::Debug;
 use std::pin::Pin;
+use std::sync::Arc;
 use std::time::SystemTime;
 
 use async_trait::async_trait;
@@ -109,5 +110,9 @@ impl StoreTrait for MemoryStore {
             .await
             .err_tip(|| "Failed to write EOF in memory store get_part")?;
         Ok(())
+    }
+
+    fn as_any(self: Arc<Self>) -> Arc<dyn std::any::Any> {
+        self
     }
 }

--- a/cas/store/ref_store.rs
+++ b/cas/store/ref_store.rs
@@ -104,4 +104,8 @@ impl StoreTrait for RefStore {
         let store = self.get_store()?;
         Pin::new(store.as_ref()).get_part(digest, writer, offset, length).await
     }
+
+    fn as_any(self: Arc<Self>) -> Arc<dyn std::any::Any> {
+        self
+    }
 }

--- a/cas/store/s3_store.rs
+++ b/cas/store/s3_store.rs
@@ -482,4 +482,8 @@ impl StoreTrait for S3Store {
             )
             .await
     }
+
+    fn as_any(self: Arc<Self>) -> Arc<dyn std::any::Any> {
+        self
+    }
 }

--- a/cas/store/size_partitioning_store.rs
+++ b/cas/store/size_partitioning_store.rs
@@ -72,4 +72,8 @@ impl StoreTrait for SizePartitioningStore {
             .get_part(digest, writer, offset, length)
             .await
     }
+
+    fn as_any(self: Arc<Self>) -> Arc<dyn std::any::Any> {
+        self
+    }
 }

--- a/cas/store/store_trait.rs
+++ b/cas/store/store_trait.rs
@@ -2,6 +2,7 @@
 
 use std::marker::Send;
 use std::pin::Pin;
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use futures::{join, try_join};
@@ -93,4 +94,6 @@ pub trait StoreTrait: Sync + Send + Unpin {
             .err_tip(|| "Failed to get_part in get_part_unchunked")
             .merge(data_res.err_tip(|| "Failed to read stream to completion in get_part_unchunked"))
     }
+
+    fn as_any(self: Arc<Self>) -> Arc<dyn std::any::Any>;
 }

--- a/cas/store/verify_store.rs
+++ b/cas/store/verify_store.rs
@@ -131,4 +131,8 @@ impl StoreTrait for VerifyStore {
     ) -> Result<(), Error> {
         self.pin_inner().get_part(digest, writer, offset, length).await
     }
+
+    fn as_any(self: Arc<Self>) -> Arc<dyn std::any::Any> {
+        self
+    }
 }


### PR DESCRIPTION
This will enable us to down-cast the stores into specific
implementations in certain cases.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/allada/turbo-cache/65)
<!-- Reviewable:end -->
