### PR TITLE
FastSlowStore now properly documented and used in LocalWorkerConfig

### DIFF
--- a/cas/cas_main.rs
+++ b/cas/cas_main.rs
@@ -96,13 +96,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     for worker_cfg in cfg.workers.unwrap_or(vec![]) {
         let spawn_fut = match worker_cfg {
             WorkerConfig::local(local_worker_cfg) => {
-                let cas_store = store_manager.get_store(&local_worker_cfg.cas_store).err_tip(|| {
-                    format!(
-                        "Failed to find store for cas_store_ref in worker config : {}",
-                        local_worker_cfg.cas_store
-                    )
-                })?;
-                let local_worker = new_local_worker(Arc::new(local_worker_cfg), cas_store.clone())
+                let fast_slow_store = store_manager
+                    .get_store(&local_worker_cfg.cas_fast_slow_store)
+                    .err_tip(|| {
+                        format!(
+                            "Failed to find store for cas_store_ref in worker config : {}",
+                            local_worker_cfg.cas_fast_slow_store
+                        )
+                    })?;
+                let local_worker = new_local_worker(Arc::new(local_worker_cfg), fast_slow_store.clone())
                     .err_tip(|| "Could not make LocalWorker")?;
                 tokio::spawn(local_worker.run())
             }

--- a/config/cas_server.rs
+++ b/config/cas_server.rs
@@ -213,23 +213,12 @@ pub struct LocalWorkerConfig {
     /// command like: "run.sh sleep 5".
     pub entrypoint_cmd: String,
 
-    /// Reference to a filesystem store (runtime enforced). This store will be used
-    /// to store a local cache of files for optimization purposes.
-    /// Must be a reference to a store implementing backends::FilesystemStore.
-    /// Note: Internally we will combine `cas_store` and this store into a
-    /// FastSlowStore. This has two effects, there will be non-file objects (like
-    /// execution proto results) and filesystem will be the `fast` store. This
-    /// means you likely don't need a layer of caching for `cas_store`.
-    pub local_filesystem_store_ref: StoreRefName,
-
     /// Underlying CAS store that the worker will use to download CAS artifacts.
-    /// This store must have the same objects that the scheduler/client-cas uses.
-    /// The scheduler will send job requests that will reference objects stored
-    /// in this store. If the objects referenced in the job request don't exist
-    /// in this store an error may be returned.
-    /// Note: We may combine this store with `local_filesystem_store_ref`.
-    /// See comment above for more info.
-    pub cas_store: StoreRefName,
+    /// This store must be a `FastSlowStore`. The `fast` store must be a
+    /// `FileSystemStore` because it will use hardlinks when building out the files
+    /// instead of copying the files. The slow store must eventually resolve to the
+    /// same store the scheduler/client uses to send job requests.
+    pub cas_fast_slow_store: StoreRefName,
 
     /// Underlying AC store that the worker will use to publish execution results
     /// into. Objects placed in this store should be reachable from the

--- a/config/examples/basic_cas.json
+++ b/config/examples/basic_cas.json
@@ -3,26 +3,35 @@
     "CAS_MAIN_STORE": {
       "memory": {
         "eviction_policy": {
-          // 100mb.
-          "max_bytes": 100000000,
+          // 1gb.
+          "max_bytes": 1000000000,
         }
       }
     },
     "AC_MAIN_STORE": {
       "memory": {
         "eviction_policy": {
-          // 10mb.
-          "max_bytes": 10000000,
+          // 100mb.
+          "max_bytes": 100000000,
         }
       }
     },
-    "WORKER_FILESYSTEM_STORE": {
-      "filesystem": {
-        "content_path": "/tmp/turbo_cache/data/content_path-cas",
-        "temp_path": "/tmp/turbo_cache/data/tmp_path-cas",
-        "eviction_policy": {
-          // 2gb.
-          "max_bytes": 2000000000,
+    "WORKER_FAST_SLOW_STORE": {
+      "fast_slow": {
+        "fast": {
+          "filesystem": {
+            "content_path": "/tmp/turbo_cache/data-worker-test/content_path-cas",
+            "temp_path": "/tmp/turbo_cache/data-worker-test/tmp_path-cas",
+            "eviction_policy": {
+              // 2gb.
+              "max_bytes": 2000000000,
+            }
+          }
+        },
+        "slow": {
+          "ref_store": {
+            "name": "CAS_MAIN_STORE",
+          }
         }
       }
     }
@@ -51,11 +60,10 @@
   "workers": [{
     "local": {
       "worker_api_endpoint": {
-        "uri": "127.0.0.1:50061",
+        "uri": "grpc://127.0.0.1:50061",
       },
       "entrypoint_cmd": "./examples/worker/local_entrypoint.sh $@",
-      "local_filesystem_store_ref": "WORKER_FILESYSTEM_STORE",
-      "cas_store": "CAS_MAIN_STORE",
+      "cas_fast_slow_store": "WORKER_FAST_SLOW_STORE",
       "ac_store": "AC_MAIN_STORE",
       "work_directory": "/tmp/turbo_cache/work",
       "platform_properties": {


### PR DESCRIPTION
We require a FastSlowStore to be used when configuring a LocalWorker.
There was a mistake made where it was enforced, but not documented.
This PR updates the documentation, renames some configs to make it
more clear and updates one of the example configs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/allada/turbo-cache/73)
<!-- Reviewable:end -->
