### PR TITLE
`is_executable` flag on files now overrides unix_mode exec flag

### DIFF
--- a/cas/worker/tests/running_actions_manager_test.rs
+++ b/cas/worker/tests/running_actions_manager_test.rs
@@ -155,7 +155,8 @@ mod running_actions_manager_tests {
             assert_eq!(std::str::from_utf8(&file2_content)?, FILE2_CONTENT);
 
             let file2_metadata = fs::metadata(&file2_path).await?;
-            assert_eq!(file2_metadata.mode() & 0o777, FILE2_MODE);
+            // Note: We sent 0o710, but because is_executable was set it turns into 0o711.
+            assert_eq!(file2_metadata.mode() & 0o777, FILE2_MODE | 0o111);
 
             assert_eq!(file2_metadata.mtime() as u64, FILE2_MTIME);
         }


### PR DESCRIPTION
Not all providers provide the unix_mode flags, but all do provide
is_executable flag for files. This PR ensures that if you pass
is_executable it will `or` the flags with `0o111` to ensure it is
actually executable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/allada/turbo-cache/74)
<!-- Reviewable:end -->
