### PR TITLE
Support deprecated symlink fields & fix bug for workers use CWD

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -7,6 +7,9 @@ build:debug -c dbg
 build:self_test --remote_instance_name=main
 build:self_test --remote_cache=grpc://127.0.0.1:50051
 
+build:self_execute --remote_executor=grpc://127.0.0.1:50051
+build:self_execute --remote_instance_name=main
+
 build --aspects=@rules_rust//rust:defs.bzl%rustfmt_aspect
 test --@rules_rust//:rustfmt.toml=//:.rustfmt.toml
 # This will make rustfmt only run on `bazel test`.

--- a/cas/grpc_service/capabilities_server.rs
+++ b/cas/grpc_service/capabilities_server.rs
@@ -100,7 +100,7 @@ impl Capabilities for CapabilitiesServer {
             }),
             high_api_version: Some(SemVer {
                 major: 2,
-                minor: 2,
+                minor: 0,
                 patch: 0,
                 prerelease: "".to_string(),
             }),

--- a/cas/grpc_service/tests/worker_api_server_test.rs
+++ b/cas/grpc_service/tests/worker_api_server_test.rs
@@ -300,7 +300,11 @@ pub mod execution_response_tests {
                             contents: Default::default(), // We don't implement this.
                             node_properties: None,
                         }],
-                        output_file_symlinks: Default::default(), // Bazel deprecated this.
+                        output_file_symlinks: vec![OutputSymlink {
+                            path: "some path3".to_string(),
+                            target: "some target3".to_string(),
+                            node_properties: None,
+                        }],
                         output_symlinks: vec![OutputSymlink {
                             path: "some path3".to_string(),
                             target: "some target3".to_string(),

--- a/cas/scheduler/tests/action_messages_test.rs
+++ b/cas/scheduler/tests/action_messages_test.rs
@@ -39,7 +39,8 @@ mod action_messages_tests {
         let execute_response: ExecuteResponse = ActionStage::Completed(ActionResult {
             output_files: vec![],
             output_folders: vec![],
-            output_symlinks: vec![],
+            output_file_symlinks: vec![],
+            output_directory_symlinks: vec![],
             exit_code: 0,
             stdout_digest: DigestInfo::new([2u8; 32], 5),
             stderr_digest: DigestInfo::new([3u8; 32], 5),

--- a/cas/scheduler/tests/scheduler_test.rs
+++ b/cas/scheduler/tests/scheduler_test.rs
@@ -477,9 +477,13 @@ mod scheduler_tests {
                 path: "123".to_string(),
                 tree_digest: DigestInfo::new([9u8; 32], 100),
             }],
-            output_symlinks: vec![SymlinkInfo {
+            output_file_symlinks: vec![SymlinkInfo {
                 name_or_path: NameOrPath::Name("foo".to_string()),
                 target: "bar".to_string(),
+            }],
+            output_directory_symlinks: vec![SymlinkInfo {
+                name_or_path: NameOrPath::Name("foo2".to_string()),
+                target: "bar2".to_string(),
             }],
             exit_code: 0,
             stdout_digest: DigestInfo::new([6u8; 32], 19),
@@ -554,7 +558,8 @@ mod scheduler_tests {
         let action_result = ActionResult {
             output_files: Default::default(),
             output_folders: Default::default(),
-            output_symlinks: Default::default(),
+            output_file_symlinks: Default::default(),
+            output_directory_symlinks: Default::default(),
             exit_code: 0,
             stdout_digest: DigestInfo::new([6u8; 32], 19),
             stderr_digest: DigestInfo::new([7u8; 32], 20),

--- a/cas/worker/tests/local_worker_test.rs
+++ b/cas/worker/tests/local_worker_test.rs
@@ -161,7 +161,8 @@ mod local_worker_tests {
         let action_result = ActionResult {
             output_files: vec![],
             output_folders: vec![],
-            output_symlinks: vec![],
+            output_file_symlinks: vec![],
+            output_directory_symlinks: vec![],
             exit_code: 5,
             stdout_digest: DigestInfo::new([21u8; 32], 10),
             stderr_digest: DigestInfo::new([22u8; 32], 10),


### PR DESCRIPTION
The documentation in the bazel remote execution proto is confusing.
It states that the output_paths will be relative to working directory
which was interpreted as CWD. This PR fixes this miss-understanding
and now files are relative to input_root.

Also, it turns out that bazel does not yet support 2.1, so we
are now populating the deprecated fields as well as the new fields.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/allada/turbo-cache/75)
<!-- Reviewable:end -->
