### PR TITLE
Fix scheduler so platform properties are properly restored

### DIFF
--- a/cas/scheduler/scheduler.rs
+++ b/cas/scheduler/scheduler.rs
@@ -342,6 +342,11 @@ impl SchedulerImpl {
             return Err(make_input_err!("{}", msg));
         }
 
+        let did_complete = match action_stage {
+            ActionStage::Completed(_) => true,
+            _ => false,
+        };
+
         Arc::make_mut(&mut running_action.action.current_state).stage = action_stage;
 
         let send_result = running_action
@@ -353,6 +358,16 @@ impl SchedulerImpl {
                 "Action {} has no more listeners during update_action()",
                 action_info.digest().str()
             );
+        }
+
+        if did_complete {
+            let worker = self
+                .workers
+                .workers
+                .get_mut(worker_id)
+                .ok_or_else(|| make_input_err!("WorkerId '{}' does not exist in workers map", worker_id))?;
+            worker.restore_platform_properties(&action_info.platform_properties);
+            self.do_try_match();
         }
 
         // TODO(allada) We should probably hold a small queue of recent actions for debugging.
@@ -469,11 +484,13 @@ impl Scheduler {
                 }
             })
             .collect();
-        for worker_id in worker_ids_to_remove {
+        for worker_id in worker_ids_to_remove.as_slice() {
             log::warn!("Worker {} timed out, removing from pool", worker_id);
             inner.immediate_evict_worker(&worker_id);
         }
-        inner.do_try_match();
+        if !worker_ids_to_remove.is_empty() {
+            inner.do_try_match();
+        }
         Ok(())
     }
 

--- a/cas/scheduler/worker.rs
+++ b/cas/scheduler/worker.rs
@@ -147,6 +147,17 @@ impl Worker {
             }
         }
     }
+
+    pub fn restore_platform_properties(&mut self, props: &PlatformProperties) {
+        for (property, prop_value) in &props.properties {
+            if let PlatformPropertyValue::Minimum(value) = prop_value {
+                let worker_props = &mut self.platform_properties.properties;
+                if let PlatformPropertyValue::Minimum(worker_value) = worker_props.get_mut(property).unwrap() {
+                    *worker_value += value;
+                }
+            }
+        }
+    }
 }
 
 impl PartialEq for Worker {


### PR DESCRIPTION
There was a bug where platform properties were not being restored
on tasks after they were completed and worker<->task match making
was not being triggered on completed tasks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/allada/turbo-cache/85)
<!-- Reviewable:end -->
