### PR TITLE
LocalWorker will now purge the work directory on construction

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,0 +1,8 @@
+bazel-bin
+bazel-out
+bazel-remote-bin
+bazel-remote-out
+bazel-remote-testlogs
+bazel-remote-turbo-cache
+bazel-testlogs
+bazel-turbo-cache

--- a/cas/worker/local_worker.rs
+++ b/cas/worker/local_worker.rs
@@ -219,6 +219,12 @@ pub async fn new_local_worker(
         .err_tip(|| "Could expand work_directory in LocalWorker")?
         .to_string();
 
+    if let Ok(path) = fs::canonicalize(&work_directory).await {
+        fs::remove_dir_all(path)
+            .await
+            .err_tip(|| "Could not remove work_directory in LocalWorker")?;
+    }
+
     fs::create_dir_all(&work_directory)
         .await
         .err_tip(|| format!("Could not make work_directory : {}", work_directory))?;

--- a/util/fs.rs
+++ b/util/fs.rs
@@ -2,7 +2,7 @@
 
 use std::fs::Metadata;
 use std::io::IoSlice;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::task::Context;
 use std::task::Poll;
@@ -219,6 +219,14 @@ pub async fn remove_file(path: impl AsRef<Path>) -> Result<(), Error> {
         .await
         .map_err(|e| make_err!(Code::Internal, "Open file semaphore closed {:?}", e))?;
     tokio::fs::remove_file(path).await.map_err(|e| e.into())
+}
+
+pub async fn canonicalize(path: impl AsRef<Path>) -> Result<PathBuf, Error> {
+    let _permit = OPEN_FILE_SEMAPHORE
+        .acquire()
+        .await
+        .map_err(|e| make_err!(Code::Internal, "Open file semaphore closed {:?}", e))?;
+    tokio::fs::canonicalize(path).await.map_err(|e| e.into())
 }
 
 pub async fn metadata(path: impl AsRef<Path>) -> Result<Metadata, Error> {


### PR DESCRIPTION
This fixes a bug when the worker does not shutdown properly there
might be stuff left over in the work_directory. Now the directory
is walked and all files and folders are removed before creation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/allada/turbo-cache/89)
<!-- Reviewable:end -->
