### PR TITLE
Scheduler will retry on internal errors

### DIFF
--- a/cas/grpc_service/tests/worker_api_server_test.rs
+++ b/cas/grpc_service/tests/worker_api_server_test.rs
@@ -17,8 +17,8 @@ use proto::build::bazel::remote::execution::v2::{
     OutputSymlink,
 };
 use proto::com::github::allada::turbo_cache::remote_execution::{
-    execute_result, update_for_worker, worker_api_server::WorkerApi, ExecuteFinishedResult, ExecuteResult,
-    KeepAliveRequest, SupportedProperties,
+    execute_result, update_for_worker, worker_api_server::WorkerApi, ExecuteResult, KeepAliveRequest,
+    SupportedProperties,
 };
 use proto::google::rpc::Status as ProtoStatus;
 use scheduler::Scheduler;
@@ -287,62 +287,60 @@ pub mod execution_response_tests {
             },
         );
         let result = ExecuteResult {
-            response: Some(execute_result::Response::Result(ExecuteFinishedResult {
-                worker_id: test_context.worker_id.to_string(),
-                action_digest: Some(action_digest.clone().into()),
-                salt: SALT,
-                execute_response: Some(ExecuteResponse {
-                    result: Some(ProtoActionResult {
-                        output_files: vec![OutputFile {
-                            path: "some path1".to_string(),
-                            digest: Some(DigestInfo::new([8u8; 32], 124).into()),
-                            is_executable: true,
-                            contents: Default::default(), // We don't implement this.
-                            node_properties: None,
-                        }],
-                        output_file_symlinks: vec![OutputSymlink {
-                            path: "some path3".to_string(),
-                            target: "some target3".to_string(),
-                            node_properties: None,
-                        }],
-                        output_symlinks: vec![OutputSymlink {
-                            path: "some path3".to_string(),
-                            target: "some target3".to_string(),
-                            node_properties: None,
-                        }],
-                        output_directories: vec![OutputDirectory {
-                            path: "some path4".to_string(),
-                            tree_digest: Some(DigestInfo::new([12u8; 32], 124).into()),
-                        }],
-                        output_directory_symlinks: Default::default(), // Bazel deprecated this.
-                        exit_code: 5,
-                        stdout_raw: Default::default(), // We don't implement this.
-                        stdout_digest: Some(DigestInfo::new([10u8; 32], 124).into()),
-                        stderr_raw: Default::default(), // We don't implement this.
-                        stderr_digest: Some(DigestInfo::new([11u8; 32], 124).into()),
-                        execution_metadata: Some(ExecutedActionMetadata {
-                            worker: test_context.worker_id.to_string(),
-                            queued_timestamp: Some(make_system_time(1).into()),
-                            worker_start_timestamp: Some(make_system_time(2).into()),
-                            worker_completed_timestamp: Some(make_system_time(3).into()),
-                            input_fetch_start_timestamp: Some(make_system_time(4).into()),
-                            input_fetch_completed_timestamp: Some(make_system_time(5).into()),
-                            execution_start_timestamp: Some(make_system_time(6).into()),
-                            execution_completed_timestamp: Some(make_system_time(7).into()),
-                            output_upload_start_timestamp: Some(make_system_time(8).into()),
-                            output_upload_completed_timestamp: Some(make_system_time(9).into()),
-                            auxiliary_metadata: vec![],
-                        }),
+            worker_id: test_context.worker_id.to_string(),
+            action_digest: Some(action_digest.clone().into()),
+            salt: SALT,
+            result: Some(execute_result::Result::ExecuteResponse(ExecuteResponse {
+                result: Some(ProtoActionResult {
+                    output_files: vec![OutputFile {
+                        path: "some path1".to_string(),
+                        digest: Some(DigestInfo::new([8u8; 32], 124).into()),
+                        is_executable: true,
+                        contents: Default::default(), // We don't implement this.
+                        node_properties: None,
+                    }],
+                    output_file_symlinks: vec![OutputSymlink {
+                        path: "some path3".to_string(),
+                        target: "some target3".to_string(),
+                        node_properties: None,
+                    }],
+                    output_symlinks: vec![OutputSymlink {
+                        path: "some path3".to_string(),
+                        target: "some target3".to_string(),
+                        node_properties: None,
+                    }],
+                    output_directories: vec![OutputDirectory {
+                        path: "some path4".to_string(),
+                        tree_digest: Some(DigestInfo::new([12u8; 32], 124).into()),
+                    }],
+                    output_directory_symlinks: Default::default(), // Bazel deprecated this.
+                    exit_code: 5,
+                    stdout_raw: Default::default(), // We don't implement this.
+                    stdout_digest: Some(DigestInfo::new([10u8; 32], 124).into()),
+                    stderr_raw: Default::default(), // We don't implement this.
+                    stderr_digest: Some(DigestInfo::new([11u8; 32], 124).into()),
+                    execution_metadata: Some(ExecutedActionMetadata {
+                        worker: test_context.worker_id.to_string(),
+                        queued_timestamp: Some(make_system_time(1).into()),
+                        worker_start_timestamp: Some(make_system_time(2).into()),
+                        worker_completed_timestamp: Some(make_system_time(3).into()),
+                        input_fetch_start_timestamp: Some(make_system_time(4).into()),
+                        input_fetch_completed_timestamp: Some(make_system_time(5).into()),
+                        execution_start_timestamp: Some(make_system_time(6).into()),
+                        execution_completed_timestamp: Some(make_system_time(7).into()),
+                        output_upload_start_timestamp: Some(make_system_time(8).into()),
+                        output_upload_completed_timestamp: Some(make_system_time(9).into()),
+                        auxiliary_metadata: vec![],
                     }),
-                    cached_result: false,
-                    status: Some(ProtoStatus {
-                        code: 9,
-                        message: "foo".to_string(),
-                        details: Default::default(),
-                    }),
-                    server_logs: server_logs,
-                    message: "TODO(blaise.bruer) We should put a reference something like bb_browser".to_string(),
                 }),
+                cached_result: false,
+                status: Some(ProtoStatus {
+                    code: 9,
+                    message: "foo".to_string(),
+                    details: Default::default(),
+                }),
+                server_logs: server_logs,
+                message: "TODO(blaise.bruer) We should put a reference something like bb_browser".to_string(),
             })),
         };
         {
@@ -362,10 +360,10 @@ pub mod execution_response_tests {
             // Check the result that the client would have received.
             client_action_state_receiver.changed().await?;
             let client_given_state = client_action_state_receiver.borrow();
-            let execute_response = if let execute_result::Response::Result(v) = result.response.unwrap() {
-                v.execute_response.unwrap()
+            let execute_response = if let execute_result::Result::ExecuteResponse(v) = result.result.unwrap() {
+                v
             } else {
-                panic!("Expected type to be Result");
+                panic!("Expected type to be ExecuteResponse");
             };
 
             assert_eq!(client_given_state.stage, execute_response.clone().try_into()?);

--- a/cas/scheduler/scheduler.rs
+++ b/cas/scheduler/scheduler.rs
@@ -3,6 +3,7 @@
 use std::cmp;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
+use std::time::SystemTime;
 
 use fast_async_mutex::mutex::Mutex;
 use lru::LruCache;
@@ -10,20 +11,31 @@ use rand::{thread_rng, Rng};
 use tokio::sync::watch;
 
 use action_messages::{ActionInfo, ActionInfoHashKey, ActionStage, ActionState};
-use common::log;
+use action_messages::{ActionResult, ExecutionMetadata};
+use common::{log, DigestInfo};
 use config::cas_server::SchedulerConfig;
-use error::{error_if, make_input_err, Error, ResultExt};
+use error::{error_if, make_err, make_input_err, Code, Error, ResultExt};
 use platform_property_manager::PlatformPropertyManager;
 use worker::{Worker, WorkerId, WorkerTimestamp, WorkerUpdate};
 
 /// Default timeout for workers in seconds.
+/// If this changes, remember to change the documentation in the config.
 const DEFAULT_WORKER_TIMEOUT_S: u64 = 5;
+
+/// Default times a job can retry before failing.
+/// If this changes, remember to change the documentation in the config.
+const DEFAULT_MAX_JOB_RETRIES: usize = 3;
+
+/// Exit code sent if there is an internal error.
+pub const INTERNAL_ERROR_EXIT_CODE: i32 = -178;
 
 /// An action that is being awaited on and last known state.
 struct AwaitedAction {
     action_info: Arc<ActionInfo>,
     current_state: Arc<ActionState>,
     notify_channel: watch::Sender<Arc<ActionState>>,
+    attempts: usize,
+    last_error: Option<Error>,
 }
 
 /// Holds the relationship of a worker that is executing a specific action.
@@ -125,6 +137,8 @@ struct SchedulerImpl {
     active_actions: HashMap<Arc<ActionInfo>, RunningAction>,
     /// Timeout of how long to evict workers if no response in this given amount of time in seconds.
     worker_timeout_s: u64,
+    /// Default times a job can retry before failing.
+    max_job_retries: usize,
 }
 
 impl SchedulerImpl {
@@ -195,6 +209,8 @@ impl SchedulerImpl {
                 action_info,
                 current_state,
                 notify_channel: tx,
+                attempts: 0,
+                last_error: None,
             },
         );
 
@@ -212,10 +228,48 @@ impl SchedulerImpl {
                 match self.active_actions.remove(&action_info) {
                     Some(running_action) => {
                         let mut awaited_action = running_action.action;
-                        Arc::make_mut(&mut awaited_action.current_state).stage = ActionStage::Queued;
-                        let send_result = awaited_action.notify_channel.send(awaited_action.current_state.clone());
-                        self.queued_actions_set.insert(action_info.clone());
-                        self.queued_actions.insert(action_info.clone(), awaited_action);
+                        let send_result = if awaited_action.attempts >= self.max_job_retries {
+                            Arc::make_mut(&mut awaited_action.current_state).stage = ActionStage::Error((
+                                awaited_action.last_error.unwrap_or_else(|| {
+                                    make_err!(
+                                        Code::Internal,
+                                        "Job cancelled because it attempted to execute too many times and failed"
+                                    )
+                                }),
+                                ActionResult {
+                                    output_files: Default::default(),
+                                    output_folders: Default::default(),
+                                    output_directory_symlinks: Default::default(),
+                                    output_file_symlinks: Default::default(),
+                                    exit_code: INTERNAL_ERROR_EXIT_CODE,
+                                    stdout_digest: DigestInfo::empty_digest(),
+                                    stderr_digest: DigestInfo::empty_digest(),
+                                    execution_metadata: ExecutionMetadata {
+                                        worker: format!("{}", worker_id),
+                                        queued_timestamp: SystemTime::UNIX_EPOCH,
+                                        worker_start_timestamp: SystemTime::UNIX_EPOCH,
+                                        worker_completed_timestamp: SystemTime::UNIX_EPOCH,
+                                        input_fetch_start_timestamp: SystemTime::UNIX_EPOCH,
+                                        input_fetch_completed_timestamp: SystemTime::UNIX_EPOCH,
+                                        execution_start_timestamp: SystemTime::UNIX_EPOCH,
+                                        execution_completed_timestamp: SystemTime::UNIX_EPOCH,
+                                        output_upload_start_timestamp: SystemTime::UNIX_EPOCH,
+                                        output_upload_completed_timestamp: SystemTime::UNIX_EPOCH,
+                                    },
+                                    server_logs: Default::default(),
+                                },
+                            ));
+                            awaited_action.notify_channel.send(awaited_action.current_state.clone())
+                            // Do not put the action back in the queue here, as this action attempted to run too many
+                            // times.
+                        } else {
+                            Arc::make_mut(&mut awaited_action.current_state).stage = ActionStage::Queued;
+                            let send_result = awaited_action.notify_channel.send(awaited_action.current_state.clone());
+                            self.queued_actions_set.insert(action_info.clone());
+                            self.queued_actions.insert(action_info.clone(), awaited_action);
+                            send_result
+                        };
+
                         if send_result.is_err() {
                             // Don't remove this task, instead we keep them around for a bit just in case
                             // the client disconnected and will reconnect and ask for same job to be executed
@@ -290,6 +344,7 @@ impl SchedulerImpl {
                         awaited_action.action_info.digest().str()
                     );
                 }
+                awaited_action.attempts += 1;
                 self.active_actions.insert(
                     action_info.clone(),
                     RunningAction {
@@ -301,6 +356,37 @@ impl SchedulerImpl {
             }
         }
         should_run_again
+    }
+
+    async fn update_worker_with_internal_error(
+        &mut self,
+        worker_id: &WorkerId,
+        action_info_hash_key: &ActionInfoHashKey,
+        err: Error,
+    ) {
+        let (action_info, mut running_action) = match self.active_actions.remove_entry(action_info_hash_key) {
+            Some((action_info, running_action)) => (action_info, running_action),
+            None => {
+                log::error!(
+                    "Could not find action info in active actions : {:?}",
+                    action_info_hash_key
+                );
+                return;
+            }
+        };
+
+        if running_action.worker_id != *worker_id {
+            log::error!(
+                "Got a result from a worker that should not be running the action, Removing worker. Expected worker {} got worker {}",
+                    running_action.worker_id, worker_id
+            );
+        }
+        running_action.action.last_error = Some(err);
+
+        // Now put it back. immediate_evict_worker() needs it to be there to send errors properly.
+        self.active_actions.insert(action_info, running_action);
+
+        self.immediate_evict_worker(worker_id);
     }
 
     async fn update_action(
@@ -398,6 +484,11 @@ impl Scheduler {
             worker_timeout_s = DEFAULT_WORKER_TIMEOUT_S;
         }
 
+        let mut max_job_retries = scheduler_cfg.max_job_retries;
+        if max_job_retries == 0 {
+            max_job_retries = DEFAULT_MAX_JOB_RETRIES;
+        }
+
         Self {
             inner: Mutex::new(SchedulerImpl {
                 queued_actions_set: HashSet::new(),
@@ -405,6 +496,7 @@ impl Scheduler {
                 workers: Workers::new(),
                 active_actions: HashMap::new(),
                 worker_timeout_s,
+                max_job_retries,
             }),
             platform_property_manager,
         }
@@ -434,6 +526,18 @@ impl Scheduler {
     pub async fn add_action(&self, action_info: ActionInfo) -> Result<watch::Receiver<Arc<ActionState>>, Error> {
         let mut inner = self.inner.lock().await;
         inner.add_action(action_info)
+    }
+
+    pub async fn update_worker_with_internal_error(
+        &self,
+        worker_id: &WorkerId,
+        action_info_hash_key: &ActionInfoHashKey,
+        err: Error,
+    ) {
+        let mut inner = self.inner.lock().await;
+        inner
+            .update_worker_with_internal_error(worker_id, action_info_hash_key, err)
+            .await
     }
 
     /// Adds an action to the scheduler for remote execution.

--- a/cas/worker/tests/local_worker_test.rs
+++ b/cas/worker/tests/local_worker_test.rs
@@ -24,8 +24,8 @@ use mock_running_actions_manager::MockRunningAction;
 use platform_property_manager::PlatformProperties;
 use proto::build::bazel::remote::execution::v2::platform::Property;
 use proto::com::github::allada::turbo_cache::remote_execution::{
-    execute_result, update_for_worker::Update, ConnectionResult, ExecuteFinishedResult, ExecuteResult, StartExecute,
-    SupportedProperties, UpdateForWorker,
+    execute_result, update_for_worker::Update, ConnectionResult, ExecuteResult, StartExecute, SupportedProperties,
+    UpdateForWorker,
 };
 
 /// Get temporary path from either `TEST_TMPDIR` or best effort temp directory if
@@ -223,12 +223,12 @@ mod local_worker_tests {
         assert_eq!(
             execution_response,
             ExecuteResult {
-                response: Some(execute_result::Response::Result(ExecuteFinishedResult {
-                    worker_id: expected_worker_id,
-                    action_digest: Some(action_digest.into()),
-                    salt: SALT,
-                    execute_response: Some(ActionStage::Completed(action_result).into()),
-                }))
+                worker_id: expected_worker_id,
+                action_digest: Some(action_digest.into()),
+                salt: SALT,
+                result: Some(execute_result::Result::ExecuteResponse(
+                    ActionStage::Completed(action_result).into()
+                )),
             }
         );
 

--- a/config/cas_server.rs
+++ b/config/cas_server.rs
@@ -64,6 +64,16 @@ pub struct SchedulerConfig {
     /// Default: 5 (seconds)
     #[serde(default)]
     pub worker_timeout_s: u64,
+
+    /// If a job returns an internal error or times out this many times when
+    /// attempting to run on a worker the scheduler will return the last error
+    /// to the client. Jobs will be retried and this configuration is to help
+    /// prevent one rogue job from infinitely retrying and taking up a lot of
+    /// resources when the task itself is the one causing the server to go
+    /// into a bad state.
+    /// Default: 3
+    #[serde(default)]
+    pub max_job_retries: usize,
 }
 
 #[derive(Deserialize, Debug, Default)]

--- a/proto/com/github/allada/turbo_cache/remote_execution/worker_api.proto
+++ b/proto/com/github/allada/turbo_cache/remote_execution/worker_api.proto
@@ -77,23 +77,8 @@ message SupportedProperties {
     reserved 2; // NextId.
 }
 
-
 /// The result of an ExecutionRequest.
 message ExecuteResult {
-  oneof response {
-    /// Result of an execution request if there were not detectable internal errors.
-    ExecuteFinishedResult result = 1;
-
-    /// An internal error. This is only present when an internal error happened that
-    /// was not recoverable. If the execution job failed but at no fault of the worker
-    /// it should not use this field and should send the error via ExecuteFinishedResult.
-    google.rpc.Status internal_error = 2;
-  }
-  reserved 3; // NextId.
-}
-
-/// Represents the result of an execution.
-message ExecuteFinishedResult {
     /// ID of the worker making the request.
     string worker_id = 1;
 
@@ -107,10 +92,19 @@ message ExecuteFinishedResult {
     /// are running or cached.
     uint64 salt = 3;
 
-    /// Result of the execution. See `build.bazel.remote.execution.v2.ExecuteResponse`
-    /// for details.
-    build.bazel.remote.execution.v2.ExecuteResponse execute_response = 4;
-    reserved 5; // NextId.
+    /// The actual response data.
+    oneof result {
+        /// Result of the execution. See `build.bazel.remote.execution.v2.ExecuteResponse`
+        /// for details.
+        build.bazel.remote.execution.v2.ExecuteResponse execute_response = 4;
+
+        /// An internal error. This is only present when an internal error happened that
+        /// was not recoverable. If the execution job failed but at no fault of the worker
+        /// it should not use this field and should send the error via execute_response.
+        google.rpc.Status internal_error = 5;
+    }
+
+    reserved 6; // NextId.
 }
 
 /// Result sent back from the server when a node connects.
@@ -149,7 +143,7 @@ message StartExecute {
     /// The action information used to execute job.
     build.bazel.remote.execution.v2.ExecuteRequest execute_request = 1;
 
-    /// See documentation in ExecuteFinishedResult::salt.
+    /// See documentation in ExecuteResult::salt.
     uint64 salt = 2;
     reserved 3; // NextId.
 }

--- a/proto/genproto/com.github.allada.turbo_cache.remote_execution.pb.rs
+++ b/proto/genproto/com.github.allada.turbo_cache.remote_execution.pb.rs
@@ -33,26 +33,6 @@ pub struct SupportedProperties {
 //// The result of an ExecutionRequest.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExecuteResult {
-    #[prost(oneof="execute_result::Response", tags="1, 2")]
-    pub response: ::core::option::Option<execute_result::Response>,
-}
-/// Nested message and enum types in `ExecuteResult`.
-pub mod execute_result {
-    #[derive(Clone, PartialEq, ::prost::Oneof)]
-    pub enum Response {
-        //// Result of an execution request if there were not detectable internal errors.
-        #[prost(message, tag="1")]
-        Result(super::ExecuteFinishedResult),
-        //// An internal error. This is only present when an internal error happened that
-        //// was not recoverable. If the execution job failed but at no fault of the worker
-        //// it should not use this field and should send the error via ExecuteFinishedResult.
-        #[prost(message, tag="2")]
-        InternalError(super::super::super::super::super::super::google::rpc::Status),
-    }
-}
-//// Represents the result of an execution.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct ExecuteFinishedResult {
     //// ID of the worker making the request.
     #[prost(string, tag="1")]
     pub worker_id: ::prost::alloc::string::String,
@@ -66,10 +46,25 @@ pub struct ExecuteFinishedResult {
     //// are running or cached.
     #[prost(uint64, tag="3")]
     pub salt: u64,
-    //// Result of the execution. See `build.bazel.remote.execution.v2.ExecuteResponse`
-    //// for details.
-    #[prost(message, optional, tag="4")]
-    pub execute_response: ::core::option::Option<super::super::super::super::super::build::bazel::remote::execution::v2::ExecuteResponse>,
+    //// The actual response data.
+    #[prost(oneof="execute_result::Result", tags="4, 5")]
+    pub result: ::core::option::Option<execute_result::Result>,
+}
+/// Nested message and enum types in `ExecuteResult`.
+pub mod execute_result {
+    //// The actual response data.
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Result {
+        //// Result of the execution. See `build.bazel.remote.execution.v2.ExecuteResponse`
+        //// for details.
+        #[prost(message, tag="4")]
+        ExecuteResponse(super::super::super::super::super::super::build::bazel::remote::execution::v2::ExecuteResponse),
+        //// An internal error. This is only present when an internal error happened that
+        //// was not recoverable. If the execution job failed but at no fault of the worker
+        //// it should not use this field and should send the error via execute_response.
+        #[prost(message, tag="5")]
+        InternalError(super::super::super::super::super::super::google::rpc::Status),
+    }
 }
 //// Result sent back from the server when a node connects.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -114,7 +109,7 @@ pub struct StartExecute {
     //// The action information used to execute job.
     #[prost(message, optional, tag="1")]
     pub execute_request: ::core::option::Option<super::super::super::super::super::build::bazel::remote::execution::v2::ExecuteRequest>,
-    //// See documentation in ExecuteFinishedResult::salt.
+    //// See documentation in ExecuteResult::salt.
     #[prost(uint64, tag="2")]
     pub salt: u64,
 }

--- a/util/common.rs
+++ b/util/common.rs
@@ -61,6 +61,18 @@ impl DigestInfo {
             .str_hash
             .get_or_create(|v| v.unwrap_or_else(|| hex::encode(self.packed_hash)))
     }
+
+    pub fn empty_digest() -> DigestInfo {
+        DigestInfo {
+            size_bytes: 0,
+            // Magic hash of a sha256 of empty string.
+            packed_hash: [
+                0xe3, 0xb0, 0xc4, 0x42, 0x98, 0xfc, 0x1c, 0x14, 0x9a, 0xfb, 0xf4, 0xc8, 0x99, 0x6f, 0xb9, 0x24, 0x27,
+                0xae, 0x41, 0xe4, 0x64, 0x9b, 0x93, 0x4c, 0xa4, 0x95, 0x99, 0x1b, 0x78, 0x52, 0xb8, 0x55,
+            ],
+            str_hash: LazyTransform::new(None),
+        }
+    }
 }
 
 impl fmt::Debug for DigestInfo {


### PR DESCRIPTION
Internal errors from the worker (not exit code errors) are now
properly forwarded up to the client, but after some retries by the
scheduler.