### PR TITLE
Overhaul filesystem store to no longer use renameat2

### DIFF
--- a/cas/store/BUILD
+++ b/cas/store/BUILD
@@ -216,6 +216,7 @@ rust_library(
     srcs = ["filesystem_store.rs"],
     deps = [
         "//config",
+        "//third_party:async_lock",
         "//third_party:bytes",
         "//third_party:filetime",
         "//third_party:futures",
@@ -395,6 +396,8 @@ rust_test(
     deps = [
         "//config",
         "//third_party:filetime",
+        "//third_party:futures",
+        "//third_party:lazy_static",
         "//third_party:pretty_assertions",
         "//third_party:rand",
         "//third_party:tokio",

--- a/cas/store/filesystem_store.rs
+++ b/cas/store/filesystem_store.rs
@@ -13,21 +13,19 @@
 // limitations under the License.
 
 use std::fmt::{Debug, Formatter};
-use std::path::Path;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
-use std::time::{Duration, SystemTime};
+use std::time::SystemTime;
 
+use async_lock::RwLock;
 use async_trait::async_trait;
 use bytes::BytesMut;
 use filetime::{set_file_atime, FileTime};
 use futures::stream::{StreamExt, TryStreamExt};
-use nix::fcntl::{renameat2, RenameFlags};
-use rand::{thread_rng, Rng};
+use futures::Future;
 use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt, SeekFrom, Take};
 use tokio::task::spawn_blocking;
-use tokio::time::sleep;
 use tokio_stream::wrappers::ReadDirStream;
 
 use buf_channel::{DropCloserReadHalf, DropCloserWriteHalf};
@@ -40,45 +38,141 @@ use traits::{StoreTrait, UploadSizeInfo};
 // Default size to allocate memory of the buffer when reading files.
 const DEFAULT_BUFF_SIZE: usize = 32 * 1024;
 
-struct FileEntry {
-    digest: DigestInfo,
+#[derive(Debug)]
+struct FolderPaths {
+    temp_path: String,
+    content_path: String,
+}
+
+#[derive(Eq, PartialEq, Debug)]
+enum PathType {
+    Content,
+    Temp,
+}
+
+type FileNameDigest = DigestInfo;
+struct EncodedFilePath {
+    folder_paths: Arc<FolderPaths>,
+    path_type: PathType,
+    digest: FileNameDigest,
+}
+
+impl EncodedFilePath {
+    #[inline]
+    fn get_file_path(&self) -> String {
+        let folder = match self.path_type {
+            PathType::Content => &self.folder_paths.content_path,
+            PathType::Temp => &self.folder_paths.temp_path,
+        };
+        to_full_path_from_digest(folder, &self.digest)
+    }
+}
+
+#[inline]
+fn to_full_path_from_digest(folder: &str, digest: &DigestInfo) -> String {
+    format!("{}/{}-{}", folder, digest.str(), digest.size_bytes)
+}
+
+// Note: We don't store the full path of the file here because it would cause
+// a lot of needless memeory bloat. There's a high chance we'll end up with a
+// lot of small files, so to prevent storing duplicate data, we store an Arc
+// to the path of the directory where the file is stored and the packed digest.
+// Resulting in usize + sizeof(DigestInfo).
+pub struct FileEntry {
     file_size: u64,
-    temp_path: Arc<String>,
-    content_path: Arc<String>,
-    // Will be the name of the file in the temp_path if it is flagged for deletion.
-    pending_delete_file_name: AtomicU64,
+
+    // Encoded this way to save memory.
+    encoded_file_path: RwLock<EncodedFilePath>,
+
+    // TODO(allada) Figure out a way to only setup these fields for tests, they
+    // are not used in production code.
     file_evicted_callback: Option<&'static (dyn Fn() + Sync)>,
+    file_unrefed_callback: Option<&'static (dyn Fn(&FileEntry) + Sync)>,
 }
 
 impl FileEntry {
-    async fn read_file_part(&self, offset: u64, length: u64) -> Result<Take<fs::FileSlot<'_>>, Error> {
-        let full_content_path = to_full_path_from_digest(&self.content_path, &self.digest);
-        let mut file = fs::open_file(&full_content_path)
-            .await
-            .err_tip(|| format!("Failed to open file in filesystem store {}", full_content_path))?;
+    pub async fn read_file_part(&self, offset: u64, length: u64) -> Result<Take<fs::FileSlot<'_>>, Error> {
+        let (mut file, full_content_path_for_debug_only) = self
+            .get_file_path_locked(|full_content_path| async move {
+                let file = fs::open_file(&full_content_path)
+                    .await
+                    .err_tip(|| format!("Failed to open file in filesystem store {}", full_content_path))?;
+                Ok((file, full_content_path))
+            })
+            .await?;
 
         file.seek(SeekFrom::Start(offset))
             .await
-            .err_tip(|| format!("Failed to seek file: {}", full_content_path))?;
+            .err_tip(|| format!("Failed to seek file: {}", full_content_path_for_debug_only))?;
         Ok(file.take(length))
     }
 
-    #[inline]
-    fn flag_moved_to_temp_file(&self, rand_file_name: u64) {
-        self.pending_delete_file_name.store(rand_file_name, Ordering::Relaxed);
+    /// This function is a safe way to extract the file name of the underlying file. To protect users from
+    /// accidentally creating undefined behavior we encourage users to do the logic they need to do with
+    /// the filename inside this function instead of extracting the filename and doing the logic outside.
+    /// This is because the filename is not guaranteed to exist after this function returns, however inside
+    /// the callback the file is always guaranteed to exist and immutable.
+    /// DO NOT USE THIS FUNCTION TO EXTRACT THE FILENAME AND STORE IT FOR LATER USE.
+    pub async fn get_file_path_locked<T, Fut: Future<Output = Result<T, Error>>, F: FnOnce(String) -> Fut>(
+        &self,
+        handler: F,
+    ) -> Result<T, Error> {
+        let encoded_file_path = self.encoded_file_path.read().await;
+        handler(encoded_file_path.get_file_path()).await
     }
 }
 
 impl Debug for FileEntry {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
         f.debug_struct("FileEntry")
-            .field("digest", &self.digest)
             .field("file_size", &self.file_size)
-            .field("temp_path", &self.temp_path)
-            .field("content_path", &self.content_path)
-            .field("pending_delete_file_name", &self.pending_delete_file_name)
+            .field("encoded_file_path", &"<behind mutex>")
             .finish()
     }
+}
+
+/// This encapsolates the logic for the edge case of if the file fails to create
+/// the cleanup of the file is handled without creating a FileEntry, which would
+/// try to cleanup the file as well during drop().
+async fn make_file_entry(
+    encoded_file_path: EncodedFilePath,
+    file_evicted_callback: Option<&'static (dyn Fn() + Sync)>,
+    file_unrefed_callback: Option<&'static (dyn Fn(&FileEntry) + Sync)>,
+) -> Result<(FileEntry, fs::FileSlot<'static>, String), Error> {
+    let temp_full_path = encoded_file_path.get_file_path();
+    let temp_file_result = fs::create_file(&temp_full_path)
+        .await
+        .err_tip(|| format!("Failed to create {} in filesystem store", temp_full_path));
+
+    match temp_file_result {
+        Ok(file) => {
+            Ok((
+                FileEntry {
+                    file_size: 0, // Unknown yet, we will fill it in later.
+                    encoded_file_path: RwLock::new(encoded_file_path),
+                    file_evicted_callback,
+                    file_unrefed_callback,
+                },
+                file,
+                temp_full_path,
+            ))
+        }
+        Err(mut err) => {
+            let remove_result = fs::remove_file(&temp_full_path)
+                .await
+                .err_tip(|| format!("Failed to remove file {} in filesystem store", temp_full_path));
+            if let Err(remove_err) = remove_result {
+                err = err.merge(remove_err);
+            }
+            log::warn!("\x1b[0;31mFilesystem Store\x1b[0m: {:?}", err);
+            Err(err)
+        }
+    }
+}
+
+fn make_temp_digest(digest: &mut DigestInfo) {
+    static DELETE_FILE_COUNTER: AtomicU64 = AtomicU64::new(0);
+    digest.packed_hash[24..].clone_from_slice(&DELETE_FILE_COUNTER.fetch_add(1, Ordering::Relaxed).to_le_bytes());
 }
 
 #[async_trait]
@@ -90,61 +184,84 @@ impl LenEntry for FileEntry {
 
     #[inline]
     async fn touch(&self) {
-        let full_content_path = to_full_path_from_digest(&self.content_path, &self.digest);
-        let set_atime_fut = spawn_blocking(move || {
-            set_file_atime(&full_content_path, FileTime::now())
-                .err_tip(|| format!("Failed to touch file in filesystem store {}", full_content_path))
-        });
-        let res = match set_atime_fut.await {
-            Ok(res) => res,
-            Err(_) => Err(make_err!(
-                Code::Internal,
-                "Failed to change atime of file due to spawn failing"
-            )),
-        };
-        if let Err(err) = res {
-            log::error!("{:?}", err);
+        let result = self
+            .get_file_path_locked(move |full_content_path| async move {
+                Ok(spawn_blocking(move || {
+                    set_file_atime(&full_content_path, FileTime::now())
+                        .err_tip(|| format!("Failed to touch file in filesystem store {}", full_content_path))
+                })
+                .await
+                .map_err(|e| {
+                    make_err!(
+                        Code::Internal,
+                        "Failed to change atime of file due to spawn failing {:?}",
+                        e
+                    )
+                })??)
+            })
+            .await;
+        if let Err(e) = result {
+            log::error!("{}", e);
         }
     }
 
+    // unref() only triggers when an item is removed from the eviction_map. It is possible
+    // that another place in code has a reference to `FileEntry` and may later read the
+    // file. To support this edge case, we first move the file to a temp file and point
+    // target file location to the new temp file. `unref()` should only ever be called once.
     #[inline]
     async fn unref(&self) {
-        let rand_file_name = thread_rng().gen::<u64>();
-
-        let from_path = to_full_path_from_digest(&self.content_path, &self.digest);
-        let to_path = to_full_path(&self.temp_path, &format!("{}", rand_file_name));
-        log::info!("\x1b[0;31mFilesystem Store\x1b[0m: Deleting: {}", &from_path);
-        // It is possible (although extremely unlikely) that another thread is reading
-        // this file while we want to delete it here. To prevent errors in either case
-        // we rename the file (since that other thread would have an open file handle)
-        // to the temp folder then delete it when the Arc reference is dropped.
-        if let Err(err) = fs::rename(&from_path, &to_path).await {
-            log::warn!("Failed to rename file from {} to {} : {:?}", from_path, to_path, err);
+        if let Some(callback) = self.file_unrefed_callback {
+            (callback)(&self);
         }
-        self.flag_moved_to_temp_file(rand_file_name);
+        {
+            let mut encoded_file_path = self.encoded_file_path.write().await;
+            if encoded_file_path.path_type == PathType::Temp {
+                // We are already a temp file that is now marked for deletion on drop.
+                // This is very rare, but most likely the rename into the content path failed.
+                return;
+            }
+            let from_path = encoded_file_path.get_file_path();
+            let mut new_digest = encoded_file_path.digest.clone();
+            make_temp_digest(&mut new_digest);
+
+            let to_path = to_full_path_from_digest(&encoded_file_path.folder_paths.temp_path, &new_digest);
+
+            log::info!(
+                "\x1b[0;31mFilesystem Store\x1b[0m: Unref {}, moving file {} to {}",
+                encoded_file_path.digest.str(),
+                &from_path,
+                &to_path
+            );
+            if let Err(err) = fs::rename(&from_path, &to_path).await {
+                log::warn!("Failed to rename file from {} to {} : {:?}", from_path, to_path, err);
+            } else {
+                encoded_file_path.path_type = PathType::Temp;
+                encoded_file_path.digest = new_digest;
+            }
+        }
     }
 }
 
+// TODO(allada) When the `file_evicted_callback` is removed, move `Drop` to EncodedFilePath impl.
 impl Drop for FileEntry {
     fn drop(&mut self) {
-        // If the file was flagged to be deleted (ie: only if unref() was called) delete
-        // the file, but in another spawn. This will ensure we don't delete the files
-        // on safe shutdown as well as not block this thread while we wait on an OS
-        // blocking call.
-        let pending_delete_file_name = self.pending_delete_file_name.load(Ordering::Relaxed);
-        if pending_delete_file_name == 0 {
+        let encoded_file_path = self.encoded_file_path.get_mut();
+        // `drop()` can be called during shutdown, so we use `path_type` flag to know if the
+        // file actually needs to be deleted.
+        if encoded_file_path.path_type == PathType::Content {
             return;
         }
+
+        let file_path = encoded_file_path.get_file_path();
         let file_evicted_callback = self.file_evicted_callback.take();
-        let full_temp_path = to_full_path(&self.temp_path, &pending_delete_file_name.to_string());
         tokio::spawn(async move {
-            log::info!("\x1b[0;31mFilesystem Store\x1b[0m: Store deleting: {}", &full_temp_path);
-            if let Err(err) = fs::remove_file(&full_temp_path).await {
-                log::warn!(
-                    "\x1b[0;31mFilesystem Store\x1b[0m: Failed to remove file {} {:?}",
-                    full_temp_path,
-                    err
-                );
+            log::info!("\x1b[0;31mFilesystem Store\x1b[0m: Deleting: {}", &file_path);
+            let result = fs::remove_file(&file_path)
+                .await
+                .err_tip(|| format!("Failed to remove file {}", file_path));
+            if let Err(err) = result {
+                log::warn!("\x1b[0;31mFilesystem Store\x1b[0m: {:?}", err);
             }
             if let Some(callback) = file_evicted_callback {
                 (callback)();
@@ -154,45 +271,36 @@ impl Drop for FileEntry {
 }
 
 #[inline]
-fn to_full_path(folder: &str, name: &str) -> String {
-    format!("{}/{}", folder, name)
-}
-
-#[inline]
-fn to_full_path_from_digest(folder: &str, digest: &DigestInfo) -> String {
-    format!("{}/{}-{}", folder, digest.str(), digest.size_bytes)
+pub fn digest_from_filename(file_name: &str) -> Result<DigestInfo, Error> {
+    let (hash, size) = file_name.split_once('-').err_tip(|| "")?;
+    let size = i64::from_str_radix(size, 10)?;
+    DigestInfo::try_new(hash, size)
 }
 
 async fn add_files_to_cache(
     evicting_map: &EvictingMap<Arc<FileEntry>, SystemTime>,
     anchor_time: &SystemTime,
-    temp_path: &Arc<String>,
-    content_path: &Arc<String>,
+    folder_paths: &Arc<FolderPaths>,
 ) -> Result<(), Error> {
-    fn make_digest(file_name: &str) -> Result<DigestInfo, Error> {
-        let (hash, size) = file_name.split_once('-').err_tip(|| "")?;
-        let size = i64::from_str_radix(size, 10)?;
-        DigestInfo::try_new(hash, size)
-    }
-
     async fn process_entry(
         evicting_map: &EvictingMap<Arc<FileEntry>, SystemTime>,
         file_name: &str,
         atime: SystemTime,
         file_size: u64,
         anchor_time: &SystemTime,
-        temp_path: &Arc<String>,
-        content_path: &Arc<String>,
+        folder_paths: &Arc<FolderPaths>,
     ) -> Result<(), Error> {
-        let digest = make_digest(&file_name)?;
+        let digest = digest_from_filename(&file_name)?;
 
         let file_entry = FileEntry {
-            digest: digest.clone(),
             file_size,
-            temp_path: temp_path.clone(),
-            content_path: content_path.clone(),
-            pending_delete_file_name: AtomicU64::new(0),
+            encoded_file_path: RwLock::new(EncodedFilePath {
+                folder_paths: folder_paths.clone(),
+                path_type: PathType::Content,
+                digest: digest.clone(),
+            }),
             file_evicted_callback: None,
+            file_unrefed_callback: None,
         };
         let time_since_anchor = anchor_time
             .duration_since(atime)
@@ -204,7 +312,7 @@ async fn add_files_to_cache(
     }
 
     let mut file_infos: Vec<(String, SystemTime, u64)> = {
-        let (_permit, dir_handle) = fs::read_dir(format!("{}/", content_path))
+        let (_permit, dir_handle) = fs::read_dir(format!("{}/", folder_paths.content_path))
             .await
             .err_tip(|| "Failed opening content directory for iterating in filesystem store")?
             .into_inner();
@@ -239,16 +347,7 @@ async fn add_files_to_cache(
 
     file_infos.sort_by(|a, b| a.1.cmp(&b.1));
     for (file_name, atime, file_size) in file_infos {
-        let result = process_entry(
-            &evicting_map,
-            &file_name,
-            atime,
-            file_size,
-            &anchor_time,
-            &temp_path,
-            &content_path,
-        )
-        .await;
+        let result = process_entry(&evicting_map, &file_name, atime, file_size, &anchor_time, &folder_paths).await;
         if let Err(err) = result {
             log::warn!(
                 "Could not add file to eviction cache, so deleting: {} - {:?}",
@@ -256,7 +355,7 @@ async fn add_files_to_cache(
                 err
             );
             // Ignore result.
-            let _ = fs::remove_file(format!("{}/{}", &content_path, &file_name)).await;
+            let _ = fs::remove_file(format!("{}/{}", &folder_paths.content_path, &file_name)).await;
         }
     }
     Ok(())
@@ -279,20 +378,22 @@ async fn prune_temp_path(temp_path: &str) -> Result<(), Error> {
 }
 
 pub struct FilesystemStore {
-    temp_path: Arc<String>,
-    content_path: Arc<String>,
+    folder_paths: Arc<FolderPaths>,
     evicting_map: EvictingMap<Arc<FileEntry>, SystemTime>,
     read_buffer_size: usize,
     file_evicted_callback: Option<&'static (dyn Fn() + Sync)>,
+    file_unrefed_callback: Option<&'static (dyn Fn(&FileEntry) + Sync)>,
 }
 
 impl FilesystemStore {
     pub async fn new_with_callback(
         config: &config::backends::FilesystemStore,
-        file_evicted_callback: &'static (dyn Fn() + Sync),
+        file_evicted_callback: Option<&'static (dyn Fn() + Sync)>,
+        file_unrefed_callback: Option<&'static (dyn Fn(&FileEntry) + Sync)>,
     ) -> Result<Self, Error> {
         let mut me = Self::new(config).await?;
-        me.file_evicted_callback = Some(file_evicted_callback);
+        me.file_evicted_callback = file_evicted_callback;
+        me.file_unrefed_callback = file_unrefed_callback;
         Ok(me)
     }
 
@@ -310,10 +411,12 @@ impl FilesystemStore {
             .await
             .err_tip(|| format!("Failed to content directory {:?}", &config.content_path))?;
 
-        let temp_path = Arc::new(config.temp_path.clone());
-        let content_path = Arc::new(config.content_path.clone());
-        add_files_to_cache(&evicting_map, &now, &temp_path, &content_path).await?;
-        prune_temp_path(&temp_path.as_ref()).await?;
+        let folder_paths = Arc::new(FolderPaths {
+            temp_path: config.temp_path.clone(),
+            content_path: config.content_path.clone(),
+        });
+        add_files_to_cache(&evicting_map, &now, &folder_paths).await?;
+        prune_temp_path(&folder_paths.temp_path).await?;
 
         let read_buffer_size = if config.read_buffer_size == 0 {
             DEFAULT_BUFF_SIZE
@@ -321,25 +424,27 @@ impl FilesystemStore {
             config.read_buffer_size as usize
         };
         let store = Self {
-            temp_path,
-            content_path,
+            folder_paths,
             evicting_map,
             read_buffer_size,
             file_evicted_callback: None,
+            file_unrefed_callback: None,
         };
         Ok(store)
     }
 
-    pub fn get_file_for_digest(&self, digest: &DigestInfo) -> String {
-        to_full_path_from_digest(self.content_path.as_ref(), &digest)
+    pub async fn get_file_entry_for_digest(&self, digest: &DigestInfo) -> Result<Arc<FileEntry>, Error> {
+        self.evicting_map
+            .get(&digest)
+            .await
+            .ok_or_else(|| make_err!(Code::NotFound, "not found in filesystem store"))
     }
 
     async fn update_file<'a>(
         self: Pin<&Self>,
-        temp_loc: &str,
+        mut entry: FileEntry,
         mut temp_file: fs::FileSlot<'a>,
-        temp_name_num: u64,
-        digest: DigestInfo,
+        final_digest: DigestInfo,
         mut reader: DropCloserReadHalf,
     ) -> Result<(), Error> {
         let mut file_size = 0;
@@ -355,7 +460,7 @@ impl FilesystemStore {
             temp_file
                 .write_all_buf(&mut data)
                 .await
-                .err_tip(|| format!("Failed to write data into filesystem store {}", temp_loc))?;
+                .err_tip(|| "Failed to write data into filesystem store")?;
             file_size += data_len as u64;
         }
 
@@ -363,66 +468,64 @@ impl FilesystemStore {
             .as_ref()
             .sync_all()
             .await
-            .err_tip(|| format!("Failed to sync_data in filesystem store {}", temp_loc))?;
+            .err_tip(|| "Failed to sync_data in filesystem store")?;
 
         drop(temp_file);
 
-        let entry = Arc::new(FileEntry {
-            digest: digest.clone(),
-            file_size,
-            temp_path: self.temp_path.clone(),
-            content_path: self.content_path.clone(),
-            pending_delete_file_name: AtomicU64::new(0),
-            file_evicted_callback: self.file_evicted_callback,
-        });
+        entry.file_size = file_size;
+        let entry = Arc::new(entry);
 
-        let final_loc = to_full_path_from_digest(&self.content_path, &digest);
+        // This sequence of events is quite ticky to understand due to the amount of triggers that
+        // happen, async'ness of it and the locking. So here is a breakdown of what happens:
+        // 1. Here will hold a write lock on any file operations of this FileEntry.
+        // 2. Then insert the entry into the evicting map. This may trigger an eviction of other
+        //    entries.
+        // 3. Eviction triggers `unref()`, which grabs a write lock on the evicted FileEntrys
+        //    during the rename.
+        // 4. It should be impossible for items to be added while eviction is happening, so there
+        //    should not be a deadlock possability. However, it is possible for the new FileEntry
+        //    to be evicted before the file is moved into place. Eviction of the newly inserted
+        //    item is not possible within the `insert()` call because the write lock inside the
+        //    eviction map. If an eviction of new item happens after `insert()` but before
+        //    `rename()` then we get to finish our operation because the `unref()` of the new item
+        //    will be blocked on us because we currently have the lock.
+        // 5. Move the file into place. Since we hold a write lock still anyone that gets our new
+        //    FileEntry (which has not yet been placed on disk) will not be able to read the file's
+        //    contents until we relese the lock.
+        {
+            let mut encoded_file_path = entry.encoded_file_path.write().await;
+            let final_encoded_file_path = EncodedFilePath {
+                folder_paths: encoded_file_path.folder_paths.clone(),
+                path_type: PathType::Content,
+                digest: final_digest.clone(),
+            };
+            let final_path = final_encoded_file_path.get_file_path();
 
-        let final_path = Path::new(&final_loc);
-        let current_path = Path::new(&temp_loc);
-        let rename_flags = if final_path.exists() {
-            RenameFlags::RENAME_EXCHANGE
-        } else {
-            RenameFlags::empty()
-        };
+            self.evicting_map.insert(final_digest.clone(), entry.clone()).await;
 
-        // TODO(allada) We should find another way to do this without needing to use this nix
-        // library. We need a way to atomically swap files, so if one location is downloading the
-        // file and another replaces the contents it doesn't error out the downloading one.
-        // We can't use two operations here because a `.has()/.get()` call might see it existing
-        // then try and download it, but if we get EXTREMELY unlucky we might move the file then
-        // another location might try to run `.get()` on it, and the file won't exist then the
-        // second rename might happen (finishing the stages), resulting in an error to the
-        // fetcher. By using the RENAME_EXCHANGE flag it solves our problem, but limits the
-        // filesystem and operating system.
-        renameat2(None, current_path, None, final_path, rename_flags)
-            .map_err(|e| {
-                make_err!(
-                    Code::NotFound,
-                    "Could not atomically swap files {} and {} in filesystem store {}",
-                    temp_loc,
-                    final_loc,
-                    e
-                )
-            })
-            .err_tip(|| "This could be due to the filesystem not supporting RENAME_EXCHANGE")?;
+            let result = fs::rename(encoded_file_path.get_file_path(), &final_path)
+                .await
+                .err_tip(|| format!("Failed to rename temp file to final path {}", final_path));
 
-        if let Some(old_item) = self.evicting_map.insert(digest, entry).await {
-            // Even though the move is atomic above, it is possible that during a hardlink operation
-            // the action will find the inode (which could be either the new or old file at this
-            // point), then create the hardlink with the queried inode. But if the file gets deleted
-            // after it grabs the inode but before the hardlink it could result in a NotFound error.
-            // By putting a delay before deleting the temp files we give some leeway so this error
-            // will be extremely rare.
-            tokio::spawn(async move {
-                const DELAY_TO_DELETE_TEMP_FILES: u64 = 100;
-                sleep(Duration::from_millis(DELAY_TO_DELETE_TEMP_FILES)).await;
-                // At this point `temp_name_num` will be the file containing the old content we
-                // are going to delete.
-                old_item.flag_moved_to_temp_file(temp_name_num);
-            });
+            // In the event our move from temp file to final file fails we need to ensure we remove
+            // the entry from our map.
+            // Remember: At this point it is possible for another thread to have a reference to
+            // `entry`, so we can't delete the file, only drop() should ever delete files.
+            if let Err(err) = result {
+                log::warn!("{}", err);
+                // Warning: To prevent deadlock we need to release our lock or during `remove_if()`
+                // it will call `unref()`, which triggers a write-lock on `encoded_file_path`.
+                drop(encoded_file_path);
+                // It is possible that the item in our map is no longer the item we inserted,
+                // So, we need to conditionally remove it only if the pointers are the same.
+                self.evicting_map
+                    .remove_if(&final_digest, |map_entry| Arc::<FileEntry>::ptr_eq(map_entry, &entry))
+                    .await;
+                return Err(err);
+            }
+            *encoded_file_path = final_encoded_file_path;
+            Ok(())
         }
-        Ok(())
     }
 }
 
@@ -438,27 +541,23 @@ impl StoreTrait for FilesystemStore {
         reader: DropCloserReadHalf,
         _upload_size: UploadSizeInfo,
     ) -> Result<(), Error> {
-        let temp_name_num = thread_rng().gen::<u64>();
-        let temp_full_path = to_full_path(&self.temp_path, &temp_name_num.to_string());
+        let mut temp_digest = digest.clone();
+        make_temp_digest(&mut temp_digest);
 
-        let temp_file = fs::create_file(&temp_full_path)
+        let (entry, temp_file, temp_full_path) = make_file_entry(
+            EncodedFilePath {
+                folder_paths: self.folder_paths.clone(),
+                path_type: PathType::Temp,
+                digest: temp_digest,
+            },
+            self.file_evicted_callback,
+            self.file_unrefed_callback,
+        )
+        .await?;
+
+        self.update_file(entry, temp_file, digest, reader)
             .await
-            .err_tip(|| "Failed to create temp file in filesystem store")?;
-
-        if let Err(err) = self
-            .update_file(&temp_full_path, temp_file, temp_name_num, digest, reader)
-            .await
-        {
-            let result = fs::remove_file(temp_full_path)
-                .await
-                .err_tip(|| "Failed to delete temp file in filesystem store");
-            if result.is_err() {
-                return Result::<(), Error>::Err(err).merge(result);
-            }
-            return Err(err);
-        }
-
-        Ok(())
+            .err_tip(|| format!("While processing with temp file {}", temp_full_path))
     }
 
     async fn get_part(

--- a/cas/store/tests/filesystem_store_test.rs
+++ b/cas/store/tests/filesystem_store_test.rs
@@ -12,22 +12,32 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::cell::RefCell;
 use std::env;
+use std::ops::DerefMut;
+use std::path::Path;
 use std::pin::Pin;
+use std::rc::Rc;
 use std::sync::atomic::{AtomicU32, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::SystemTime;
 
 use filetime::{set_file_atime, FileTime};
+use futures::executor::block_on;
+use futures::task::Poll;
+use futures::{poll, Future};
+use lazy_static::lazy_static;
 use rand::{thread_rng, Rng};
 use tokio::io::AsyncReadExt;
+use tokio::sync::Barrier;
 use tokio_stream::{wrappers::ReadDirStream, StreamExt};
+use traits::UploadSizeInfo;
 
 use buf_channel::{make_buf_channel_pair, DropCloserReadHalf};
 use common::{fs, DigestInfo};
 use config;
 use error::{Error, ResultExt};
-use filesystem_store::FilesystemStore;
+use filesystem_store::{digest_from_filename, FileEntry, FilesystemStore};
 use traits::StoreTrait;
 
 /// Get temporary path from either `TEST_TMPDIR` or best effort temp directory if
@@ -128,7 +138,8 @@ mod filesystem_store_tests {
                     }),
                     ..Default::default()
                 },
-                &on_file_delete,
+                Some(&on_file_delete),
+                None,
             )
             .await?,
         );
@@ -198,7 +209,8 @@ mod filesystem_store_tests {
                     }),
                     read_buffer_size: 1,
                 },
-                &on_file_delete,
+                Some(&on_file_delete),
+                None,
             )
             .await?,
         );
@@ -308,7 +320,8 @@ mod filesystem_store_tests {
                     }),
                     read_buffer_size: 1,
                 },
-                &on_file_delete,
+                Some(&on_file_delete),
+                None,
             )
             .await?,
         );
@@ -401,13 +414,17 @@ mod filesystem_store_tests {
         // Insert data into store.
         store.as_ref().update_oneshot(digest1.clone(), VALUE1.into()).await?;
 
-        let path = store.get_file_for_digest(&digest1);
+        let file_entry = store.get_file_entry_for_digest(&digest1).await?;
+        file_entry
+            .get_file_path_locked(move |path| async move {
+                // Set atime to along time ago.
+                set_file_atime(&path, FileTime::zero())?;
 
-        // Set atime to along time ago.
-        set_file_atime(&path, FileTime::zero())?;
-
-        // Check to ensure it was set to zero from previous command.
-        assert_eq!(fs::metadata(&path).await?.accessed()?, SystemTime::UNIX_EPOCH);
+                // Check to ensure it was set to zero from previous command.
+                assert_eq!(fs::metadata(&path).await?.accessed()?, SystemTime::UNIX_EPOCH);
+                Ok(())
+            })
+            .await?;
 
         // Now touch digest1.
         let data = store
@@ -416,8 +433,13 @@ mod filesystem_store_tests {
             .await?;
         assert_eq!(data, VALUE1.as_bytes());
 
-        // Ensure it was updated.
-        assert!(fs::metadata(&path).await?.accessed()? > SystemTime::UNIX_EPOCH);
+        file_entry
+            .get_file_path_locked(move |path| async move {
+                // Ensure it was updated.
+                assert!(fs::metadata(&path).await?.accessed()? > SystemTime::UNIX_EPOCH);
+                Ok(())
+            })
+            .await?;
 
         Ok(())
     }
@@ -438,13 +460,17 @@ mod filesystem_store_tests {
         // Insert data into store.
         store.as_ref().update_oneshot(digest1.clone(), VALUE1.into()).await?;
 
-        let path = store.get_file_for_digest(&digest1);
+        let file_entry = store.get_file_entry_for_digest(&digest1).await?;
+        file_entry
+            .get_file_path_locked(move |path| async move {
+                // Set atime to along time ago.
+                set_file_atime(&path, FileTime::zero())?;
 
-        // Set atime to along time ago.
-        set_file_atime(&path, FileTime::zero())?;
-
-        // Check to ensure it was set to zero from previous command.
-        assert_eq!(fs::metadata(&path).await?.accessed()?, SystemTime::UNIX_EPOCH);
+                // Check to ensure it was set to zero from previous command.
+                assert_eq!(fs::metadata(&path).await?.accessed()?, SystemTime::UNIX_EPOCH);
+                Ok(())
+            })
+            .await?;
 
         // Now touch digest1.
         let data = store
@@ -453,8 +479,225 @@ mod filesystem_store_tests {
             .await?;
         assert_eq!(data, VALUE1.as_bytes());
 
-        // Ensure it was updated.
-        assert!(fs::metadata(&path).await?.accessed()? > SystemTime::UNIX_EPOCH);
+        file_entry
+            .get_file_path_locked(move |path| async move {
+                // Ensure it was updated.
+                assert!(fs::metadata(&path).await?.accessed()? > SystemTime::UNIX_EPOCH);
+                Ok(())
+            })
+            .await?;
+
+        Ok(())
+    }
+
+    // Test to ensure that if we are holding a reference to `FileEntry` and the contents are
+    // replaced, the `FileEntry` continues to use the old data.
+    // `FileEntry` file contents should be immutable for the lifetime of the object.
+    #[tokio::test]
+    async fn digest_contents_replaced_continues_using_old_data() -> Result<(), Error> {
+        let digest = DigestInfo::try_new(&HASH1, VALUE1.len())?;
+
+        let store = Box::pin(
+            FilesystemStore::new(&config::backends::FilesystemStore {
+                content_path: make_temp_path("content_path"),
+                temp_path: make_temp_path("temp_path"),
+                eviction_policy: None,
+                ..Default::default()
+            })
+            .await?,
+        );
+        // Insert data into store.
+        store.as_ref().update_oneshot(digest.clone(), VALUE1.into()).await?;
+        let file_entry = store.get_file_entry_for_digest(&digest).await?;
+        {
+            // The file contents should equal our initial data.
+            let mut reader = file_entry.read_file_part(0, u64::MAX).await?;
+            let mut file_contents = String::new();
+            reader.read_to_string(&mut file_contents).await?;
+            assert_eq!(file_contents, VALUE1);
+        }
+
+        // Now replace the data.
+        store.as_ref().update_oneshot(digest.clone(), VALUE2.into()).await?;
+
+        {
+            // The file contents still equal our old data.
+            let mut reader = file_entry.read_file_part(0, u64::MAX).await?;
+            let mut file_contents = String::new();
+            reader.read_to_string(&mut file_contents).await?;
+            assert_eq!(file_contents, VALUE1);
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn eviction_on_insert_calls_unref_once() -> Result<(), Error> {
+        const BIG_VALUE: &str = "0123";
+        let small_digest = DigestInfo::try_new(&HASH1, VALUE1.len())?;
+        let big_digest = DigestInfo::try_new(&HASH1, BIG_VALUE.len())?;
+
+        lazy_static! {
+            static ref UNREFED_DIGESTS: Mutex<Vec<DigestInfo>> = Mutex::new(Vec::new());
+        }
+        fn on_unref_callback(file_entry: &FileEntry) {
+            block_on(file_entry.get_file_path_locked(move |path_str| async move {
+                let path = Path::new(&path_str);
+                let digest = digest_from_filename(path.file_name().unwrap().to_str().unwrap()).unwrap();
+                UNREFED_DIGESTS.lock().unwrap().push(digest);
+                Ok(())
+            }))
+            .unwrap();
+        }
+
+        let store = Box::pin(
+            FilesystemStore::new_with_callback(
+                &config::backends::FilesystemStore {
+                    content_path: make_temp_path("content_path"),
+                    temp_path: make_temp_path("temp_path"),
+                    eviction_policy: Some(config::backends::EvictionPolicy {
+                        max_bytes: 5,
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                },
+                None,
+                Some(&on_unref_callback),
+            )
+            .await?,
+        );
+        // Insert data into store.
+        store
+            .as_ref()
+            .update_oneshot(small_digest.clone(), VALUE1.into())
+            .await?;
+        store
+            .as_ref()
+            .update_oneshot(big_digest.clone(), BIG_VALUE.into())
+            .await?;
+
+        {
+            // Our first digest should have been unrefed exactly once.
+            let unrefed_digests = UNREFED_DIGESTS.lock().unwrap();
+            assert_eq!(unrefed_digests.len(), 1, "Expected exactly 1 unrefed digest");
+            assert_eq!(unrefed_digests[0], small_digest, "Expected digest to match");
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn rename_on_insert_fails_due_to_filesystem_error_proper_cleanup_happens() -> Result<(), Error> {
+        let digest = DigestInfo::try_new(&HASH1, VALUE1.len())?;
+
+        let content_path = make_temp_path("content_path");
+        let temp_path = make_temp_path("temp_path");
+
+        lazy_static! {
+            static ref FILE_DELETED_BARRIER: Arc<Barrier> = Arc::new(Barrier::new(2));
+        }
+
+        fn on_file_drop() {
+            tokio::spawn(FILE_DELETED_BARRIER.wait());
+        }
+
+        let store = Box::pin(
+            FilesystemStore::new_with_callback(
+                &config::backends::FilesystemStore {
+                    content_path: content_path.clone(),
+                    temp_path: temp_path.clone(),
+                    eviction_policy: None,
+                    ..Default::default()
+                },
+                Some(&on_file_drop),
+                None,
+            )
+            .await?,
+        );
+
+        let (mut tx, rx) = make_buf_channel_pair();
+        let update_fut = Rc::new(RefCell::new(store.as_ref().update(
+            digest.clone(),
+            rx,
+            UploadSizeInfo::MaxSize(100),
+        )));
+        // This will process as much of the future as it can before it needs to pause.
+        // Our temp file will be created and opened and ready to have contents streamed
+        // to it.
+        assert_eq!(poll!(update_fut.borrow_mut().deref_mut())?, Poll::Pending);
+        const INITIAL_CONTENT: &str = "hello";
+        tx.send(INITIAL_CONTENT.into()).await?;
+
+        // Now we extract that temp file that is generated.
+        async fn wait_for_temp_file<Fut: Future<Output = Result<(), Error>>, F: Fn() -> Fut>(
+            temp_path: &str,
+            yield_fn: F,
+        ) -> Result<fs::DirEntry, Error> {
+            loop {
+                // Just in case there's a
+                yield_fn().await?;
+                let (_permit, dir_handle) = fs::read_dir(&temp_path).await?.into_inner();
+                let mut read_dir_stream = ReadDirStream::new(dir_handle);
+                if let Some(dir_entry) = read_dir_stream.next().await {
+                    assert!(
+                        read_dir_stream.next().await.is_none(),
+                        "There should only be one file in temp directory"
+                    );
+                    let dir_entry = dir_entry?;
+                    // Ensure we have written to the file too. This ensures we have an open file handle.
+                    // Failing to do this may result in the file existing, but the `update_fut` not actually
+                    // sending data to it yet.
+                    if dir_entry.metadata().await?.len() >= INITIAL_CONTENT.len() as u64 {
+                        return Ok(dir_entry);
+                    }
+                }
+            }
+            // Unreachable.
+        }
+        wait_for_temp_file(&temp_path, || {
+            let update_fut_clone = update_fut.clone();
+            async move {
+                // This will ensure we yield to our future and other potential spawns.
+                tokio::task::yield_now().await;
+                assert_eq!(poll!(update_fut_clone.borrow_mut().deref_mut())?, Poll::Pending);
+                Ok(())
+            }
+        })
+        .await?;
+
+        // Now make it impossible for the file to be moved into the final path.
+        // This will trigger an error on `rename()`.
+        fs::remove_dir_all(&content_path).await?;
+
+        // Because send_eof() waits for shutdown of the rx side, we cannot just await in this thread.
+        tokio::spawn(async move {
+            tx.send_eof().await.unwrap();
+        });
+
+        // Now finish waiting on update(). This should reuslt in an error because we deleted our dest
+        // folder.
+        let update_result = update_fut.borrow_mut().deref_mut().await;
+        assert!(
+            update_result.is_err(),
+            "Expected update to fail due to temp file being deleted before rename"
+        );
+
+        // Delete may happen on another thread, so wait for it.
+        FILE_DELETED_BARRIER.wait().await;
+
+        // Now it should have cleaned up it's temp files.
+        {
+            // Ensure `temp_path` is empty.
+            let (_permit, dir_handle) = fs::read_dir(&temp_path).await?.into_inner();
+            let mut read_dir_stream = ReadDirStream::new(dir_handle);
+            assert!(
+                read_dir_stream.next().await.is_none(),
+                "File found in temp_path after update() rename failure"
+            );
+        }
+
+        // Finally ensure that our entry is not in the store.
+        assert_eq!(store.as_ref().has(digest).await?, None, "Entry should not be in store");
 
         Ok(())
     }

--- a/cas/worker/running_actions_manager.rs
+++ b/cas/worker/running_actions_manager.rs
@@ -85,7 +85,6 @@ pub fn download_to_directory<'a>(
                 .err_tip(|| "Expected Digest to exist in Directory::file::digest")?
                 .try_into()
                 .err_tip(|| "In Directory::file::digest")?;
-            let src = filesystem_store.get_file_for_digest(&digest);
             let dest = format!("{}/{}", current_directory, file.name);
             let mut mtime = None;
             let mut unix_mode = None;
@@ -94,11 +93,17 @@ pub fn download_to_directory<'a>(
                 unix_mode = properties.unix_mode;
             }
             let is_executable = file.is_executable;
+            let digest_copy = digest.clone();
             futures.push(
                 cas_store
                     .populate_fast_store(digest.clone())
                     .and_then(move |_| async move {
-                        fs::hard_link(src, &dest)
+                        let file_entry = filesystem_store
+                            .get_file_entry_for_digest(&digest_copy)
+                            .await
+                            .err_tip(|| "During hard link")?;
+                        file_entry
+                            .get_file_path_locked(|src| fs::hard_link(src, &dest))
                             .await
                             .map_err(|e| make_err!(Code::Internal, "Could not make hardlink, {:?} : {}", e, dest))?;
                         if is_executable {

--- a/util/fs.rs
+++ b/util/fs.rs
@@ -27,6 +27,7 @@ use tokio::sync::{Semaphore, SemaphorePermit};
 /// We wrap all tokio::fs items in our own wrapper so we can limit the number of outstanding
 /// open files at any given time. This will greatly reduce the chance we'll hit open file limit
 /// issues.
+pub use tokio::fs::DirEntry;
 
 #[derive(Debug)]
 pub struct FileSlot<'a> {

--- a/util/tests/evicting_map_test.rs
+++ b/util/tests/evicting_map_test.rs
@@ -261,7 +261,7 @@ mod evicting_map_tests {
     }
 
     #[tokio::test]
-    async fn unref_not_called_on_replace() -> Result<(), Error> {
+    async fn unref_called_on_replace() -> Result<(), Error> {
         #[derive(Debug)]
         struct MockEntry {
             data: Bytes,
@@ -318,7 +318,7 @@ mod evicting_map_tests {
         let existing_entry = evicting_map.get(&DigestInfo::try_new(HASH1, 0)?).await.unwrap();
         assert_eq!(existing_entry.data, DATA2);
 
-        assert_eq!(entry1.unref_called.load(Ordering::Relaxed), false);
+        assert_eq!(entry1.unref_called.load(Ordering::Relaxed), true);
         assert_eq!(entry2.unref_called.load(Ordering::Relaxed), false);
 
         Ok(())


### PR DESCRIPTION
This PR introduces a massive overhaul to remove the dependency on renameat2 as well as fix bugs in the process. The bugs found are:
* unref() was not being called when insert() replaced an item
* Various extremely unlikely corner cases around files being created, replaced, deleted
* Edge case where the contents of a FileEntry could use the wrong data on data replacement (although very unlikely).

The paradime of "FileEntry" entries and it's corresponding file are now full immutable, meaning if the file gets replaced it will generate a new FileEntry and shuffle the files around so both may be read uninterrupted at any point.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/allada/turbo-cache/108)
<!-- Reviewable:end -->
