### PR TITLE
Simplify proto generation logic

### DIFF
--- a/proto/BUILD
+++ b/proto/BUILD
@@ -1,19 +1,14 @@
 load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library")
 
-# These build rules will do the following:
-# 1. Fetch all .proto files under in this directory
-# 2. Generate .pb.rs files for each one of these proto files
-# 3. Generate a lib.rs file that should be used as the import path used
-#    for all dependencies.
-# 4. Test to ensure the checked-in genproto/*.pb.rs file matches the generated
-#    code.
-
-_proto_files = glob(["**/*.proto"])
-_proto_base_files = depset(['.'.join(file[:-len(".proto")].split('/')[:-1]) for file in _proto_files]).to_list()
-_proto_base_files_without_google = [name for name in _proto_base_files if name != "google.protobuf"]
-_genproto_files = ["%s.pb.rs" % pkg for pkg in _proto_base_files_without_google]
-
-_checked_in_proto_files = ["genproto/%s" % file for file in _genproto_files]
+PROTO_NAMES = [
+    "build.bazel.remote.execution.v2",
+    "build.bazel.semver",
+    "com.github.allada.turbo_cache.remote_execution",
+    "google.api",
+    "google.bytestream",
+    "google.longrunning",
+    "google.rpc",
+]
 
 rust_binary(
     name = "gen_protos_tool",
@@ -23,20 +18,39 @@ rust_binary(
         "//third_party:prost_build",
         "//third_party:tonic_build",
         "@rules_rust//:rustfmt",
-    ]
+    ],
 )
 
 genrule(
     name = "gen_rs_protos",
-    srcs = _proto_files,
-    outs = _genproto_files,
-    cmd = "\n".join([
-        "set -e",
-        "export PROTOC=$(execpath @com_google_protobuf//:protoc)",
-        "$(execpath :gen_protos_tool) --output_dir $(RULEDIR) " + " ".join([
-            ("--input $(location :%s)" % file) for file in _proto_files
-        ]),
-    ] + ["mv $(RULEDIR)/{name}.rs $(RULEDIR)/{name}.pb.rs".format(name=name) for name in _proto_base_files_without_google]),
+    srcs = [
+        "build/bazel/remote/execution/v2/remote_execution.proto",
+        "build/bazel/semver/semver.proto",
+        "com/github/allada/turbo_cache/remote_execution/worker_api.proto",
+        "google/api/annotations.proto",
+        "google/api/client.proto",
+        "google/api/http.proto",
+        "google/bytestream/bytestream.proto",
+        "google/longrunning/operations.proto",
+        "google/protobuf/any.proto",
+        "google/protobuf/descriptor.proto",
+        "google/protobuf/duration.proto",
+        "google/protobuf/empty.proto",
+        "google/protobuf/timestamp.proto",
+        "google/protobuf/wrappers.proto",
+        "google/rpc/status.proto",
+    ],
+    outs = ["{}.pb.rs".format(name) for name in PROTO_NAMES],
+    cmd = '''
+        set -e
+        export PROTOC=$(execpath @com_google_protobuf//:protoc)
+
+        $(execpath :gen_protos_tool) $(SRCS) -o $(RULEDIR)
+
+        for file in $(RULEDIR)/*.rs; do
+            mv -- "$$file" "$${file%.rs}.pb.rs"
+        done
+        ''',
     tools = [
         ":gen_protos_tool",
         "@com_google_protobuf//:protoc",
@@ -46,13 +60,11 @@ genrule(
 py_binary(
     name = "gen_lib_rs_tool",
     srcs = ["gen_lib_rs_tool.py"],
-    python_version = "PY3",
-    srcs_version = "PY3",
 )
 
 genrule(
     name = "gen_lib_rs",
-    srcs = _genproto_files,
+    srcs = [":gen_rs_protos"],
     outs = ["lib.rs"],
     cmd = "$(execpath :gen_lib_rs_tool) --rootdir $(RULEDIR) $(SRCS) > $@",
     tools = [":gen_lib_rs_tool"],
@@ -62,31 +74,28 @@ rust_library(
     name = "proto",
     srcs = [
         ":gen_lib_rs",
-    ] + _genproto_files,
+        ":gen_rs_protos",
+    ],
+    visibility = ["//visibility:public"],
     deps = [
         "//third_party:prost",
         "//third_party:prost_types",
         "//third_party:tonic",
     ],
-    visibility = ["//visibility:public"],
 )
 
 py_binary(
     name = "update_protos",
     srcs = ["update_protos.py"],
-    args = ["--update"] + _proto_base_files_without_google,
-    data = _genproto_files,
-    python_version = "PY3",
-    srcs_version = "PY3",
+    args = ["--update"] + PROTO_NAMES,
+    data = [":gen_rs_protos"],
 )
 
 # Test to ensure the proto files are in sync with the checked in files.
 py_test(
     name = "update_protos_test",
     srcs = ["update_protos.py"],
-    args = ["--check"] + _proto_base_files_without_google,
-    data = _genproto_files + glob(_checked_in_proto_files),
+    args = ["--check"] + PROTO_NAMES,
+    data = glob(["genproto/*.pb.rs"]) + [":gen_rs_protos"],
     main = "update_protos.py",
-    python_version = "PY3",
-    srcs_version = "PY3",
 )

--- a/proto/gen_protos_tool.rs
+++ b/proto/gen_protos_tool.rs
@@ -2,18 +2,15 @@ use clap::{Arg, ArgAction, Command};
 use prost_build::Config;
 use std::path::PathBuf;
 use std::vec::Vec;
-use tonic_build;
 
 fn main() -> std::io::Result<()> {
     let matches = Command::new("Rust gRPC Codegen")
         .about("Codegen grpc/protobuf bindings for rust")
         .arg(
-            Arg::new("input")
-                .short('i')
-                .long("input")
+            Arg::new("inputs")
                 .required(true)
                 .action(ArgAction::Append)
-                .help("Input proto file"),
+                .help("Input proto files"),
         )
         .arg(
             Arg::new("output_dir")
@@ -23,7 +20,7 @@ fn main() -> std::io::Result<()> {
                 .help("Output directory"),
         )
         .get_matches();
-    let paths = matches.get_many::<String>("input").unwrap().collect::<Vec<&String>>();
+    let paths = matches.get_many::<String>("inputs").unwrap().collect::<Vec<&String>>();
     let output_dir = PathBuf::from(matches.get_one::<String>("output_dir").unwrap());
 
     let mut config = Config::new();

--- a/proto/update_protos.py
+++ b/proto/update_protos.py
@@ -81,7 +81,7 @@ def check(proto_packages):
             print("%s out of date" % dst)
             failed = True
     if failed:
-        print("To update, run: 'bazel run //proto:update_protos'")
+        print("To update, run: 'bazel run proto:update_protos'")
         raise SystemExit(1)
 
 


### PR DESCRIPTION
Instead of invoking the gen_protos_tool on every file, make it run on all proto files at once. This way we can simplify the proto build file.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/allada/turbo-cache/111)
<!-- Reviewable:end -->
