### PR TITLE
Add timestamps to executor jobs

### DIFF
--- a/cas/scheduler/tests/scheduler_test.rs
+++ b/cas/scheduler/tests/scheduler_test.rs
@@ -103,6 +103,28 @@ mod scheduler_tests {
 
     const WORKER_TIMEOUT_S: u64 = 100;
 
+    fn check_and_reset_timestamp(msg_for_worker: &mut UpdateForWorker) {
+        match &mut msg_for_worker.update {
+            Some(update) => match update {
+                update_for_worker::Update::StartAction(start_execute) => {
+                    if let Some(timestamp) = &start_execute.queued_timestamp {
+                        assert!(
+                            SystemTime::now()
+                                .duration_since(SystemTime::try_from(timestamp.clone()).expect("Unknown time set"))
+                                .expect("Time went backwards")
+                                .as_millis()
+                                < 500,
+                            "Queued timestamp is out of range"
+                        );
+                    }
+                    start_execute.queued_timestamp = None;
+                }
+                _ => {}
+            },
+            _ => {}
+        }
+    }
+
     #[tokio::test]
     async fn basic_add_action_with_one_worker_test() -> Result<(), Error> {
         const WORKER_ID: WorkerId = WorkerId(0x123456789111);
@@ -124,9 +146,11 @@ mod scheduler_tests {
                         ..Default::default()
                     }),
                     salt: 0,
+                    queued_timestamp: None,
                 })),
             };
-            let msg_for_worker = rx_from_worker.recv().await.unwrap();
+            let mut msg_for_worker = rx_from_worker.recv().await.unwrap();
+            check_and_reset_timestamp(&mut msg_for_worker);
             assert_eq!(msg_for_worker, expected_msg_for_worker);
         }
         {
@@ -174,11 +198,13 @@ mod scheduler_tests {
                     ..Default::default()
                 }),
                 salt: 0,
+                queued_timestamp: None,
             })),
         };
         {
             // Worker1 should now see execution request.
-            let msg_for_worker = rx_from_worker1.recv().await.unwrap();
+            let mut msg_for_worker = rx_from_worker1.recv().await.unwrap();
+            check_and_reset_timestamp(&mut msg_for_worker);
             assert_eq!(msg_for_worker, execution_request_for_worker);
         }
 
@@ -211,7 +237,8 @@ mod scheduler_tests {
         }
         {
             // Worker2 should now see execution request.
-            let msg_for_worker = rx_from_worker2.recv().await.unwrap();
+            let mut msg_for_worker = rx_from_worker2.recv().await.unwrap();
+            check_and_reset_timestamp(&mut msg_for_worker);
             assert_eq!(msg_for_worker, execution_request_for_worker);
         }
 
@@ -260,9 +287,11 @@ mod scheduler_tests {
                         ..Default::default()
                     }),
                     salt: 0,
+                    queued_timestamp: None,
                 })),
             };
-            let msg_for_worker = rx_from_worker2.recv().await.unwrap();
+            let mut msg_for_worker = rx_from_worker2.recv().await.unwrap();
+            check_and_reset_timestamp(&mut msg_for_worker);
             assert_eq!(msg_for_worker, expected_msg_for_worker);
         }
         {
@@ -322,9 +351,11 @@ mod scheduler_tests {
                         ..Default::default()
                     }),
                     salt: 0,
+                    queued_timestamp: None,
                 })),
             };
-            let msg_for_worker = rx_from_worker.recv().await.unwrap();
+            let mut msg_for_worker = rx_from_worker.recv().await.unwrap();
+            check_and_reset_timestamp(&mut msg_for_worker);
             assert_eq!(msg_for_worker, expected_msg_for_worker);
         }
 
@@ -406,12 +437,14 @@ mod scheduler_tests {
                     ..Default::default()
                 }),
                 salt: 0,
+                queued_timestamp: None,
             })),
         };
 
         {
             // Worker1 should now see execution request.
-            let msg_for_worker = rx_from_worker1.recv().await.unwrap();
+            let mut msg_for_worker = rx_from_worker1.recv().await.unwrap();
+            check_and_reset_timestamp(&mut msg_for_worker);
             assert_eq!(msg_for_worker, execution_request_for_worker);
         }
 
@@ -448,7 +481,8 @@ mod scheduler_tests {
         }
         {
             // Worker2 should now see execution request.
-            let msg_for_worker = rx_from_worker2.recv().await.unwrap();
+            let mut msg_for_worker = rx_from_worker2.recv().await.unwrap();
+            check_and_reset_timestamp(&mut msg_for_worker);
             assert_eq!(msg_for_worker, execution_request_for_worker);
         }
 
@@ -652,9 +686,11 @@ mod scheduler_tests {
                         ..Default::default()
                     }),
                     salt: 0,
+                    queued_timestamp: None,
                 })),
             };
-            let msg_for_worker = rx_from_worker.recv().await.unwrap();
+            let mut msg_for_worker = rx_from_worker.recv().await.unwrap();
+            check_and_reset_timestamp(&mut msg_for_worker);
             assert_eq!(msg_for_worker, expected_msg_for_worker);
         }
 

--- a/cas/scheduler/worker.rs
+++ b/cas/scheduler/worker.rs
@@ -141,6 +141,7 @@ impl Worker {
         self.send_msg_to_worker(update_for_worker::Update::StartAction(StartExecute {
             execute_request: Some(action_info_clone.into()),
             salt: *action_info.salt(),
+            queued_timestamp: Some(action_info.insert_timestamp.into()),
         }))
     }
 

--- a/cas/worker/tests/local_worker_test.rs
+++ b/cas/worker/tests/local_worker_test.rs
@@ -184,6 +184,7 @@ mod local_worker_tests {
                     update: Some(Update::StartAction(StartExecute {
                         execute_request: Some(action_info.into()),
                         salt: SALT,
+                        queued_timestamp: None,
                     })),
                 })?)
                 .await

--- a/proto/com/github/allada/turbo_cache/remote_execution/worker_api.proto
+++ b/proto/com/github/allada/turbo_cache/remote_execution/worker_api.proto
@@ -18,6 +18,7 @@ package com.github.allada.turbo_cache.remote_execution;
 
 import "build/bazel/remote/execution/v2/remote_execution.proto";
 import "google/protobuf/empty.proto";
+import "google/protobuf/timestamp.proto";
 import "google/rpc/status.proto";
 
 /// This API describes how schedulers communicate with Worker nodes.
@@ -157,5 +158,10 @@ message StartExecute {
 
     /// See documentation in ExecuteResult::salt.
     uint64 salt = 2;
-    reserved 3; // NextId.
+
+    /// The time at which the command was added to the queue to allow population
+    /// of the ActionResult
+    google.protobuf.Timestamp queued_timestamp = 3;
+
+    reserved 4; // NextId.
 }

--- a/proto/genproto/com.github.allada.turbo_cache.remote_execution.pb.rs
+++ b/proto/genproto/com.github.allada.turbo_cache.remote_execution.pb.rs
@@ -142,6 +142,10 @@ pub struct StartExecute {
     /// / See documentation in ExecuteResult::salt.
     #[prost(uint64, tag = "2")]
     pub salt: u64,
+    /// / The time at which the command was added to the queue to allow population
+    /// / of the ActionResult
+    #[prost(message, optional, tag = "3")]
+    pub queued_timestamp: ::core::option::Option<::prost_types::Timestamp>,
 }
 /// Generated client implementations.
 pub mod worker_api_client {


### PR DESCRIPTION
It kinda does what it says on the tin.  Hopefully this is a nice easy one.

I know you asked for refactors before features, but I thought this might be an easy one over the long discussion I can see us having on things like swapping async Mutex's to sync ones.