### PR TITLE
Document that users should use `-c opt` for release builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,20 @@ This project was first created due to frustration with similar projects not work
 * Bazel 5.0.0+
 * `libssl-dev` package installed (ie: `apt install libssl-dev` or `yum install libssl-dev`)
 
-### Building
+### Building for deployment
+```
+$ bazel build -c opt //cas
+```
+
+> **Note**
+> Failing to use the `-c opt` flag will result in a very slow binary (~10x slower). 
+
+### Building for development
 ```
 $ bazel build //cas
 ```
 
-This will place an executable in `./bazel-bin/cas/cas` that will start the service.
+These will place an executable in `./bazel-bin/cas/cas` that will start the service.
 
 ### Configure
 


### PR DESCRIPTION
Added documentation about needing to use `-c opt` for production builds.

I did some crude testing of various LTO testing as well and found that it does not appear to improve performance enough for the potential problems it might produce.

Results:
```
$ bazel build //cas
93.426  bazel unoptimized
663.727 turbocache unoptimized

$ bazel build -c opt //cas
10.077  bazel optimized
48.151  turbocache optimized

$ bazel build -c opt --@rules_rust//:extra_rustc_flags=--codegen=lto=thin //cas
9.673   bazel with thinlto
48.654  turbocache optimized with thinlto

$ bazel build -c opt --@rules_rust//:extra_rustc_flags=--codegen=lto=fat //cas
9.965   bazel with fatlto
47.874  turbocache optimized with fatlto
```

From these results `fat` is best, but this was only over 1 run, so it is unknown if it really is much faster. The compile time for the binary was significantly slower though.

fixes #110

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/allada/turbo-cache/125)
<!-- Reviewable:end -->
