### PR TITLE
Kill currently running actions on scheduler disconnect.

### DIFF
--- a/cas/worker/local_worker.rs
+++ b/cas/worker/local_worker.rs
@@ -351,6 +351,10 @@ impl<T: WorkerApiClientTrait, U: RunningActionsManager> LocalWorker<T, U> {
 
             // Now listen for connections and run all other services.
             if let Err(e) = inner.run(update_for_worker_stream).await {
+                // Kill off any existing actions because if we re-connect, we'll
+                // get some more and it might resource lock us.
+                self.running_actions_manager.kill_all().await;
+
                 (error_handler)(e).await;
                 continue; // Try to connect again.
             }

--- a/cas/worker/running_actions_manager.rs
+++ b/cas/worker/running_actions_manager.rs
@@ -380,7 +380,8 @@ struct RunningActionImplExecutionResult {
 struct RunningActionImplState {
     command_proto: Option<ProtoCommand>,
     // TODO(allada) Kill is not implemented yet, but is instrumented.
-    _kill_channel_tx: Option<oneshot::Sender<()>>,
+    // However, it is used if the worker disconnects to destroy current jobs.
+    kill_channel_tx: Option<oneshot::Sender<()>>,
     kill_channel_rx: Option<oneshot::Receiver<()>>,
     execution_result: Option<RunningActionImplExecutionResult>,
     action_result: Option<ActionResult>,
@@ -413,7 +414,7 @@ impl RunningActionImpl {
             state: Mutex::new(RunningActionImplState {
                 command_proto: None,
                 kill_channel_rx: Some(kill_channel_rx),
-                _kill_channel_tx: Some(kill_channel_tx),
+                kill_channel_tx: Some(kill_channel_tx),
                 execution_result: None,
                 action_result: None,
                 execution_metadata,
@@ -503,7 +504,9 @@ impl RunningAction for RunningActionImpl {
                 state
                     .kill_channel_rx
                     .take()
-                    .err_tip(|| "Expected state to have kill_channel_rx in execute()")?,
+                    .err_tip(|| "Expected state to have kill_channel_rx in execute()")?
+                    // This is important as we may be killed at any point.
+                    .fuse(),
             )
         };
         let args = &command_proto.arguments[..];
@@ -575,7 +578,7 @@ impl RunningAction for RunningActionImpl {
                 },
                 _ = &mut kill_channel_rx => {
                     if let Err(e) = child_process.start_kill() {
-                        log::error!("Could kill process in RunningActionsManager : {:?}", e);
+                        log::error!("Could not kill process in RunningActionsManager : {:?}", e);
                     }
                 },
             }
@@ -797,6 +800,8 @@ pub trait RunningActionsManager: Sync + Send + Sized + Unpin + 'static {
     ) -> Result<Arc<Self::RunningAction>, Error>;
 
     async fn get_action(&self, action_id: &ActionId) -> Result<Arc<Self::RunningAction>, Error>;
+
+    async fn kill_all(&self);
 }
 
 /// A function to get the current system time, used to allow mocking for tests
@@ -885,6 +890,16 @@ impl RunningActionsManagerImpl {
         })?;
         Ok(())
     }
+
+    async fn kill_action(action: Arc<RunningActionImpl>) {
+        let mut action_state = action.state.lock().await;
+        if let Some(kill_channel_tx) = action_state.kill_channel_tx.take() {
+            match kill_channel_tx.send(()) {
+                Err(_) => log::error!("Error sending kill to running action"),
+                _ => (),
+            }
+        }
+    }
 }
 
 #[async_trait]
@@ -938,5 +953,19 @@ impl RunningActionsManager for RunningActionsManagerImpl {
             .err_tip(|| format!("Action '{:?}' not found", action_id))?
             .upgrade()
             .err_tip(|| "Could not upgrade RunningAction Arc")?)
+    }
+
+    async fn kill_all(&self) {
+        let kill_actions = {
+            let running_actions = self.running_actions.lock().await;
+            futures::future::join_all(
+                running_actions
+                    .iter()
+                    .filter_map(|(_action_id, action)| action.upgrade())
+                    .map(|action| Box::pin(Self::kill_action(action))),
+            )
+        };
+        // Await the actions after dropping the Mutex.
+        kill_actions.await;
     }
 }

--- a/cas/worker/tests/running_actions_manager_test.rs
+++ b/cas/worker/tests/running_actions_manager_test.rs
@@ -37,7 +37,9 @@ use proto::build::bazel::remote::execution::v2::{
     Action, Command, Directory, DirectoryNode, ExecuteRequest, FileNode, NodeProperties, SymlinkNode, Tree,
 };
 use proto::com::github::allada::turbo_cache::remote_execution::StartExecute;
-use running_actions_manager::{download_to_directory, RunningAction, RunningActionsManager, RunningActionsManagerImpl};
+use running_actions_manager::{
+    download_to_directory, RunningAction, RunningActionImpl, RunningActionsManager, RunningActionsManagerImpl,
+};
 use store::Store;
 
 /// Get temporary path from either `TEST_TMPDIR` or best effort temp directory if
@@ -77,6 +79,20 @@ async fn setup_stores() -> Result<
         Pin::into_inner(slow_store.clone()),
     )));
     Ok((fast_store, slow_store, cas_store))
+}
+
+async fn run_action(action: Arc<RunningActionImpl>) -> Result<ActionResult, Error> {
+    action
+        .clone()
+        .prepare_action()
+        .and_then(|action| action.execute())
+        .and_then(|action| action.upload_results())
+        .and_then(|action| action.get_finished_result())
+        .then(|result| async move {
+            action.cleanup().await?;
+            result
+        })
+        .await
 }
 
 const NOW_TIME: u64 = 10000;
@@ -501,17 +517,7 @@ mod running_actions_manager_tests {
                 )
                 .await?;
 
-            running_action_impl
-                .clone()
-                .prepare_action()
-                .and_then(|action| action.execute())
-                .and_then(|action| action.upload_results())
-                .and_then(|action| action.get_finished_result())
-                .then(|result| async move {
-                    running_action_impl.cleanup().await?;
-                    result
-                })
-                .await?
+            run_action(running_action_impl.clone()).await?
         };
         let file_content = slow_store
             .as_ref()
@@ -627,17 +633,7 @@ mod running_actions_manager_tests {
                 )
                 .await?;
 
-            running_action_impl
-                .clone()
-                .prepare_action()
-                .and_then(|action| action.execute())
-                .and_then(|action| action.upload_results())
-                .and_then(|action| action.get_finished_result())
-                .then(|result| async move {
-                    running_action_impl.cleanup().await?;
-                    result
-                })
-                .await?
+            run_action(running_action_impl.clone()).await?
         };
         let tree =
             get_and_decode_digest::<Tree>(slow_store.as_ref(), &action_result.output_folders[0].tree_digest).await?;
@@ -779,17 +775,7 @@ mod running_actions_manager_tests {
                 )
                 .await?;
 
-            running_action_impl
-                .clone()
-                .prepare_action()
-                .and_then(|action| action.execute())
-                .and_then(|action| action.upload_results())
-                .and_then(|action| action.get_finished_result())
-                .then(|result| async move {
-                    running_action_impl.cleanup().await?;
-                    result
-                })
-                .await?
+            run_action(running_action_impl.clone()).await?
         };
         let mut clock_time = make_system_time(0);
         assert_eq!(
@@ -829,6 +815,57 @@ mod running_actions_manager_tests {
             "Expected empty directory at {}",
             root_work_directory
         );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn kill_ends_action() -> Result<(), Box<dyn std::error::Error>> {
+        let (_, _, cas_store) = setup_stores().await?;
+        let root_work_directory = make_temp_path("root_work_directory");
+        fs::create_dir_all(&root_work_directory).await?;
+
+        let running_actions_manager = Arc::new(RunningActionsManagerImpl::new(
+            root_work_directory.clone(),
+            Pin::into_inner(cas_store.clone()),
+        )?);
+        const WORKER_ID: &str = "foo_worker_id";
+        const SALT: u64 = 55;
+        let command = Command {
+            arguments: vec!["sh".to_string(), "-c".to_string(), "sleep infinity".to_string()],
+            output_paths: vec![],
+            working_directory: ".".to_string(),
+            ..Default::default()
+        };
+        let command_digest = serialize_and_upload_message(&command, cas_store.as_ref()).await?;
+        let input_root_digest = serialize_and_upload_message(&Directory::default(), cas_store.as_ref()).await?;
+        let action = Action {
+            command_digest: Some(command_digest.into()),
+            input_root_digest: Some(input_root_digest.into()),
+            ..Default::default()
+        };
+        let action_digest = serialize_and_upload_message(&action, cas_store.as_ref()).await?;
+
+        let running_action_impl = running_actions_manager
+            .clone()
+            .create_and_add_action(
+                WORKER_ID.to_string(),
+                StartExecute {
+                    execute_request: Some(ExecuteRequest {
+                        action_digest: Some(action_digest.into()),
+                        ..Default::default()
+                    }),
+                    salt: SALT,
+                    queued_timestamp: Some(make_system_time(1000).into()),
+                },
+            )
+            .await?;
+
+        // Start the action and kill it at the same time.
+        let result = futures::join!(run_action(running_action_impl), running_actions_manager.kill_all()).0?;
+
+        // Check that the action was killed.
+        assert_eq!(9, result.exit_code);
+
         Ok(())
     }
 }


### PR DESCRIPTION
When the scheduler disconnects from the worker it continues to run the actions.  This is a pointless endeavour as, even if the scheduler reconnects, the actions will have been purged and the results will be ignored.  Therefore don't waste CPU (or RAM) and kill jobs immediately.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/allada/turbo-cache/126)
<!-- Reviewable:end -->
