### PR TITLE
If a stale work directory exists, try deleting it.

### DIFF
--- a/cas/worker/BUILD
+++ b/cas/worker/BUILD
@@ -135,6 +135,7 @@ rust_test(
         "//util:common",
         "//util:error",
         "@crate_index//:futures",
+        "@crate_index//:hex",
         "@crate_index//:pretty_assertions",
         "@crate_index//:prost",
         "@crate_index//:rand",


### PR DESCRIPTION
There are times when a job is not cleaned up due to improper shutdown and the work directory still existed from before.  This PR tries to clean it up and create a new one if this occurs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/allada/turbo-cache/129)
<!-- Reviewable:end -->
