### PR TITLE
Move the scheduler to a thread rather than use a Mutex.

### DIFF
--- a/cas/scheduler/BUILD
+++ b/cas/scheduler/BUILD
@@ -28,7 +28,6 @@ rust_library(
         "//config",
         "//util:common",
         "//util:error",
-        "@crate_index//:async-lock",
         "@crate_index//:lru",
         "@crate_index//:rand",
         "@crate_index//:tokio",


### PR DESCRIPTION
For the same reasoning as #133 the scheduler makes heavy use of a Mutex.  This means that the threads that perform operations on the data in the SchedulerImpl are constantly switching context.  It is much more efficient to have a single thread dealing with all data requests for the internal data of SchedulerImpl and then have channels send requests to perform mutations on that data.

By ensuring all data access to SchedulerImpl is performed on a single thread, all locking is removed and instead channels are used to pass data in and out of the scheduler.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/allada/turbo-cache/134)
<!-- Reviewable:end -->
