### PR TITLE
Fixes the `entrypoint_cmd` configuration

### DIFF
--- a/cas/worker/BUILD
+++ b/cas/worker/BUILD
@@ -122,6 +122,7 @@ rust_library(
 rust_test(
     name = "running_actions_manager_test",
     srcs = ["tests/running_actions_manager_test.rs"],
+    data = ["tests/wrapper_for_test.sh"],
     deps = [
         ":running_actions_manager",
         "//cas/scheduler:action_messages",

--- a/cas/worker/local_worker.rs
+++ b/cas/worker/local_worker.rs
@@ -235,9 +235,14 @@ pub async fn new_local_worker(
     fs::create_dir_all(&config.work_directory)
         .await
         .err_tip(|| format!("Could not make work_directory : {}", config.work_directory))?;
-
+    let entrypoint_cmd = if config.entrypoint_cmd.is_empty() {
+        None
+    } else {
+        Some(Arc::new(config.entrypoint_cmd.clone()))
+    };
     let running_actions_manager = Arc::new(RunningActionsManagerImpl::new(
-        config.work_directory.to_string(),
+        config.work_directory.clone(),
+        entrypoint_cmd,
         fast_slow_store,
     )?)
     .clone();

--- a/cas/worker/tests/wrapper_for_test.sh
+++ b/cas/worker/tests/wrapper_for_test.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# This script is used only to make sure wrapper scripts work in
+# running_actions_manager_test.rs.
+
+# Print some static text to stderr. This is what the test uses to
+# make sure the script did run.
+>&2 printf "Wrapper script did run"
+
+# Now run the real command.
+exec "$@"

--- a/config/cas_server.rs
+++ b/config/cas_server.rs
@@ -283,11 +283,10 @@ pub struct LocalWorkerConfig {
 
     /// The command to execute on every execution request. This will be parsed as
     /// a command + arguments (not shell).
-    /// '$@' has a special meaning in that all the arguments will expand into this
-    /// location.
-    /// Example: "run.sh $@" and a job with command: "sleep 5" will result in a
+    /// Example: "run.sh" and a job with command: "sleep 5" will result in a
     /// command like: "run.sh sleep 5".
-    #[serde(deserialize_with = "convert_string_with_shellexpand")]
+    /// Default: <Use the command from the job request>.
+    #[serde(default, deserialize_with = "convert_string_with_shellexpand")]
     pub entrypoint_cmd: String,
 
     /// Underlying CAS store that the worker will use to download CAS artifacts.

--- a/config/examples/basic_cas.json
+++ b/config/examples/basic_cas.json
@@ -62,7 +62,6 @@
       "worker_api_endpoint": {
         "uri": "grpc://127.0.0.1:50061",
       },
-      "entrypoint_cmd": "./examples/worker/local_entrypoint.sh $@",
       "cas_fast_slow_store": "WORKER_FAST_SLOW_STORE",
       "ac_store": "AC_MAIN_STORE",
       "work_directory": "/tmp/turbo_cache/work",

--- a/deployment-examples/docker-compose/worker.json
+++ b/deployment-examples/docker-compose/worker.json
@@ -32,7 +32,6 @@
       "worker_api_endpoint": {
         "uri": "grpc://${SCHEDULER_ENDPOINT:-127.0.0.1}:50061",
       },
-      "entrypoint_cmd": "$@",
       "cas_fast_slow_store": "WORKER_FAST_SLOW_STORE",
       "ac_store": "GRPC_LOCAL_STORE",
       "work_directory": "~/.cache/turbo-cache/work",

--- a/deployment-examples/terraform/scripts/worker.json
+++ b/deployment-examples/terraform/scripts/worker.json
@@ -88,7 +88,6 @@
       "worker_api_endpoint": {
         "uri": "grpc://${SCHEDULER_ENDPOINT:-127.0.0.1}:50061",
       },
-      "entrypoint_cmd": "$@",
       "cas_fast_slow_store": "WORKER_FAST_SLOW_STORE",
       "ac_store": "AC_S3_STORE",
       "work_directory": "/worker/work",

--- a/run_integration_tests.sh
+++ b/run_integration_tests.sh
@@ -93,6 +93,7 @@ for pattern in "${TEST_PATTERNS[@]}"; do
       echo "$FILENAME passed"
     else
       echo "$FILENAME failed with exit code $EXIT_CODE"
+      docker-compose logs
       exit $EXIT_CODE
     fi
     docker-compose down


### PR DESCRIPTION
Fixes an oversight where the design called for `entrypoint_cmd` config, but it was never implemented.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/allada/turbo-cache/139)
<!-- Reviewable:end -->
