### PR TITLE
Change the version of C++ used for protoc to the earliest supported.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Use latest supported C++ version for protoc.
-build --cxxopt=-std=c++20 --host_cxxopt=-std=c++20 --repo_env=BAZEL_CXXOPTS=-std=c++20
+# Use the earliest supported C++ version for protoc.
+build --cxxopt=-std=c++14 --host_cxxopt=-std=c++14 --repo_env=BAZEL_CXXOPTS=-std=c++14
 
 build --test_output=errors
 


### PR DESCRIPTION
This allows builds to continue to work on older platforms.

This closes #146.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/allada/turbo-cache/147)
<!-- Reviewable:end -->
