### PR TITLE
Goma places the platform properties in the command

### DIFF
--- a/cas/grpc_service/execution_server.rs
+++ b/cas/grpc_service/execution_server.rs
@@ -30,7 +30,7 @@ use config::cas_server::{ExecutionConfig, InstanceName};
 use error::{make_input_err, Error, ResultExt};
 use platform_property_manager::PlatformProperties;
 use proto::build::bazel::remote::execution::v2::{
-    execution_server::Execution, execution_server::ExecutionServer as Server, Action, ExecuteRequest,
+    execution_server::Execution, execution_server::ExecutionServer as Server, Action, Command, ExecuteRequest,
     WaitExecutionRequest,
 };
 use proto::google::longrunning::Operation;
@@ -84,8 +84,23 @@ impl InstanceInfo {
                     .scheduler
                     .get_platform_property_manager()
                     .make_prop_value(&property.name, &property.value)
-                    .err_tip(|| "Failed to convert platform property in queue_action")?;
+                    .err_tip(|| "Failed to convert platform property in build_action_info")?;
                 platform_properties.insert(property.name.clone(), platform_property);
+            }
+        }
+
+        // Goma puts the properties in the Command.
+        if platform_properties.is_empty() {
+            let command = get_and_decode_digest::<Command>(self.cas_pin(), &command_digest).await?;
+            if let Some(platform) = &command.platform {
+                for property in &platform.properties {
+                    let platform_property = self
+                        .scheduler
+                        .get_platform_property_manager()
+                        .make_prop_value(&property.name, &property.value)
+                        .err_tip(|| "Failed to convert command platform property in build_action_info")?;
+                    platform_properties.insert(property.name.clone(), platform_property);
+                }
             }
         }
 


### PR DESCRIPTION
This is the deprecated way of populating properties, but it's required to support Goma.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/allada/turbo-cache/159)
<!-- Reviewable:end -->
