### PR TITLE
Implement a GrpcScheduler to forward.

### DIFF
--- a/cas/grpc_service/capabilities_server.rs
+++ b/cas/grpc_service/capabilities_server.rs
@@ -36,7 +36,7 @@ pub struct CapabilitiesServer {
 }
 
 impl CapabilitiesServer {
-    pub fn new(
+    pub async fn new(
         config: &HashMap<InstanceName, CapabilitiesConfig>,
         scheduler_map: &HashMap<String, Arc<dyn ActionScheduler>>,
     ) -> Result<Self, Error> {
@@ -54,7 +54,12 @@ impl CapabilitiesServer {
                     })?
                     .clone();
 
-                for (platform_key, _) in scheduler.get_platform_property_manager().get_known_properties() {
+                for (platform_key, _) in scheduler
+                    .get_platform_property_manager(&instance_name)
+                    .await
+                    .err_tip(|| format!("Failed to get platform properties for {}", instance_name))?
+                    .get_known_properties()
+                {
                     properties.push(platform_key.clone());
                 }
             }

--- a/cas/grpc_service/execution_server.rs
+++ b/cas/grpc_service/execution_server.rs
@@ -23,7 +23,7 @@ use tokio_stream::wrappers::WatchStream;
 use tonic::{Request, Response, Status};
 
 use ac_utils::get_and_decode_digest;
-use action_messages::{ActionInfo, ActionInfoHashKey};
+use action_messages::{ActionInfo, ActionInfoHashKey, DEFAULT_EXECUTION_PRIORITY};
 use common::{log, DigestInfo};
 use config::cas_server::{ExecutionConfig, InstanceName};
 use error::{make_input_err, Error, ResultExt};
@@ -35,9 +35,6 @@ use proto::build::bazel::remote::execution::v2::{
 use proto::google::longrunning::Operation;
 use scheduler::ActionScheduler;
 use store::{Store, StoreManager};
-
-/// Default priority remote execution jobs will get when not provided.
-const DEFAULT_EXECUTION_PRIORITY: i32 = 0;
 
 struct InstanceInfo {
     scheduler: Arc<dyn ActionScheduler>,
@@ -55,6 +52,7 @@ impl InstanceInfo {
         action_digest: DigestInfo,
         action: &Action,
         priority: i32,
+        skip_cache_lookup: bool,
     ) -> Result<ActionInfo, Error> {
         let command_digest = DigestInfo::try_from(
             action
@@ -81,7 +79,9 @@ impl InstanceInfo {
             for property in &platform.properties {
                 let platform_property = self
                     .scheduler
-                    .get_platform_property_manager()
+                    .get_platform_property_manager(&instance_name)
+                    .await
+                    .err_tip(|| "Failed to get platform properties in build_action_info")?
                     .make_prop_value(&property.name, &property.value)
                     .err_tip(|| "Failed to convert platform property in build_action_info")?;
                 platform_properties.insert(property.name.clone(), platform_property);
@@ -95,7 +95,9 @@ impl InstanceInfo {
                 for property in &platform.properties {
                     let platform_property = self
                         .scheduler
-                        .get_platform_property_manager()
+                        .get_platform_property_manager(&instance_name)
+                        .await
+                        .err_tip(|| "Failed to get platform properties in build_action_info")?
                         .make_prop_value(&property.name, &property.value)
                         .err_tip(|| "Failed to convert command platform property in build_action_info")?;
                     platform_properties.insert(property.name.clone(), platform_property);
@@ -120,6 +122,7 @@ impl InstanceInfo {
                     0
                 },
             },
+            skip_cache_lookup,
         })
     }
 }
@@ -182,7 +185,7 @@ impl ExecutionServer {
 
         let action = get_and_decode_digest::<Action>(instance_info.cas_pin(), &digest).await?;
         let action_info = instance_info
-            .build_action_info(instance_name, digest, &action, priority)
+            .build_action_info(instance_name, digest, &action, priority, execute_req.skip_cache_lookup)
             .await?;
 
         let rx = instance_info

--- a/cas/grpc_service/tests/worker_api_server_test.rs
+++ b/cas/grpc_service/tests/worker_api_server_test.rs
@@ -289,6 +289,7 @@ pub mod execution_response_tests {
                 digest: action_digest.clone(),
                 salt: SALT,
             },
+            skip_cache_lookup: true,
         };
         let mut client_action_state_receiver = test_context.scheduler.add_action(action_info).await?;
 

--- a/cas/scheduler/BUILD
+++ b/cas/scheduler/BUILD
@@ -56,6 +56,28 @@ rust_library(
 )
 
 rust_library(
+    name = "grpc_scheduler",
+    srcs = ["grpc_scheduler.rs"],
+    visibility = [
+        "//cas:__pkg__",
+        "//cas:__subpackages__",
+    ],
+    proc_macro_deps = ["@crate_index//:async-trait"],
+    deps = [
+        ":action_messages",
+        ":platform_property_manager",
+        ":scheduler",
+        "//config",
+        "//proto",
+        "//util:common",
+        "//util:error",
+        "@crate_index//:parking_lot",
+        "@crate_index//:tokio",
+        "@crate_index//:tonic",
+    ],
+)
+
+rust_library(
     name = "default_scheduler_factory",
     srcs = ["default_scheduler_factory.rs"],
     visibility = [
@@ -63,6 +85,7 @@ rust_library(
         "//cas:__subpackages__",
     ],
     deps = [
+        ":grpc_scheduler",
         ":scheduler",
         ":simple_scheduler",
         "//config",

--- a/cas/scheduler/default_scheduler_factory.rs
+++ b/cas/scheduler/default_scheduler_factory.rs
@@ -19,6 +19,7 @@ use futures::Future;
 
 use config::schedulers::SchedulerConfig;
 use error::Error;
+use grpc_scheduler::GrpcScheduler;
 use scheduler::{ActionScheduler, WorkerScheduler};
 use simple_scheduler::SimpleScheduler;
 
@@ -33,6 +34,7 @@ pub fn scheduler_factory<'a>(
                 let scheduler = Arc::new(SimpleScheduler::new(&config));
                 (Some(scheduler.clone()), Some(scheduler))
             }
+            SchedulerConfig::grpc(config) => (Some(Arc::new(GrpcScheduler::new(&config).await?)), None),
         };
         Ok(scheduler)
     })

--- a/cas/scheduler/grpc_scheduler.rs
+++ b/cas/scheduler/grpc_scheduler.rs
@@ -1,0 +1,129 @@
+// Copyright 2023 The Turbo Cache Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use parking_lot::Mutex;
+use tokio::sync::watch;
+use tonic::{transport, Request};
+
+use action_messages::{ActionInfo, ActionState, DEFAULT_EXECUTION_PRIORITY};
+use common::log;
+use config;
+use error::{make_err, Code, Error, ResultExt};
+use platform_property_manager::PlatformPropertyManager;
+use proto::build::bazel::remote::execution::v2::{
+    capabilities_client::CapabilitiesClient, execution_client::ExecutionClient, ExecuteRequest, ExecutionPolicy,
+    GetCapabilitiesRequest,
+};
+use scheduler::ActionScheduler;
+
+pub struct GrpcScheduler {
+    endpoint: transport::Channel,
+    platform_property_managers: Mutex<HashMap<String, Arc<PlatformPropertyManager>>>,
+}
+
+impl GrpcScheduler {
+    pub async fn new(config: &config::schedulers::GrpcScheduler) -> Result<Self, Error> {
+        let endpoint = transport::Endpoint::new(config.endpoint.clone())
+            .err_tip(|| format!("Could not parse {} in GrpcScheduler", config.endpoint))?
+            .connect()
+            .await
+            .err_tip(|| format!("Could not connect to {} in GrpcScheduler", config.endpoint))?;
+
+        Ok(Self {
+            endpoint,
+            platform_property_managers: Mutex::new(HashMap::new()),
+        })
+    }
+}
+
+#[async_trait]
+impl ActionScheduler for GrpcScheduler {
+    async fn get_platform_property_manager(&self, instance_name: &str) -> Result<Arc<PlatformPropertyManager>, Error> {
+        if let Some(platform_property_manager) = self.platform_property_managers.lock().get(instance_name) {
+            return Ok(platform_property_manager.clone());
+        }
+
+        // Not in the cache, lookup the capabilities with the upstream.
+        let mut capabilities_client = CapabilitiesClient::new(self.endpoint.clone());
+        let capabilities = capabilities_client
+            .get_capabilities(GetCapabilitiesRequest {
+                instance_name: instance_name.to_string(),
+            })
+            .await?
+            .into_inner();
+        let platform_property_manager = Arc::new(PlatformPropertyManager::new(
+            capabilities
+                .execution_capabilities
+                .err_tip(|| "Unable to get execution properties in GrpcScheduler")?
+                .supported_node_properties
+                .iter()
+                .map(|property| (property.clone(), config::schedulers::PropertyType::Exact))
+                .collect(),
+        ));
+
+        self.platform_property_managers
+            .lock()
+            .insert(instance_name.to_string(), platform_property_manager.clone());
+        Ok(platform_property_manager)
+    }
+
+    async fn add_action(&self, action_info: ActionInfo) -> Result<watch::Receiver<Arc<ActionState>>, Error> {
+        let execution_policy = if action_info.priority == DEFAULT_EXECUTION_PRIORITY {
+            None
+        } else {
+            Some(ExecutionPolicy {
+                priority: action_info.priority,
+            })
+        };
+        let request = ExecuteRequest {
+            instance_name: action_info.instance_name.clone(),
+            skip_cache_lookup: action_info.skip_cache_lookup,
+            action_digest: Some(action_info.digest().into()),
+            execution_policy,
+            // TODO: Get me from the original request, not very important as we ignore it.
+            results_cache_policy: None,
+        };
+        let mut result_stream = ExecutionClient::new(self.endpoint.clone())
+            .execute(Request::new(request))
+            .await
+            .err_tip(|| "Sending action to upstream scheduler")?
+            .into_inner();
+        if let Some(initial_response) = result_stream
+            .message()
+            .await
+            .err_tip(|| "Recieving response from upstream scheduler")?
+        {
+            let (tx, rx) = watch::channel(Arc::new(initial_response.try_into()?));
+            tokio::spawn(async move {
+                while let Ok(Some(response)) = result_stream.message().await {
+                    match response.try_into() {
+                        Ok(response) => {
+                            if let Err(err) = tx.send(Arc::new(response)) {
+                                log::info!("Client disconnected in GrpcScheduler: {}", err);
+                                return;
+                            }
+                        }
+                        Err(err) => log::error!("Error converting response to watch in GrpcScheduler: {}", err),
+                    }
+                }
+            });
+            return Ok(rx);
+        }
+        Err(make_err!(Code::Internal, "Upstream scheduler didn't accept action."))
+    }
+}

--- a/cas/scheduler/scheduler.rs
+++ b/cas/scheduler/scheduler.rs
@@ -27,7 +27,7 @@ use worker::{Worker, WorkerId, WorkerTimestamp};
 #[async_trait]
 pub trait ActionScheduler: Sync + Send + Unpin {
     /// Returns the platform property manager.
-    fn get_platform_property_manager(&self) -> &PlatformPropertyManager;
+    async fn get_platform_property_manager(&self, instance_name: &str) -> Result<Arc<PlatformPropertyManager>, Error>;
 
     /// Adds an action to the scheduler for remote execution.
     async fn add_action(&self, action_info: ActionInfo) -> Result<watch::Receiver<Arc<ActionState>>, Error>;

--- a/cas/scheduler/simple_scheduler.rs
+++ b/cas/scheduler/simple_scheduler.rs
@@ -15,7 +15,6 @@
 use std::cmp;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
-use std::time::SystemTime;
 
 use async_trait::async_trait;
 use futures::Future;
@@ -26,8 +25,8 @@ use tokio::sync::{watch, Notify};
 use tokio::task::JoinHandle;
 use tokio::time::Duration;
 
-use action_messages::{ActionInfo, ActionInfoHashKey, ActionResult, ActionStage, ActionState, ExecutionMetadata};
-use common::{log, DigestInfo};
+use action_messages::{ActionInfo, ActionInfoHashKey, ActionResult, ActionStage, ActionState};
+use common::log;
 use config;
 use error::{error_if, make_err, make_input_err, Code, Error, ResultExt};
 use platform_property_manager::PlatformPropertyManager;
@@ -41,9 +40,6 @@ const DEFAULT_WORKER_TIMEOUT_S: u64 = 5;
 /// Default times a job can retry before failing.
 /// If this changes, remember to change the documentation in the config.
 const DEFAULT_MAX_JOB_RETRIES: usize = 3;
-
-/// Exit code sent if there is an internal error.
-pub const INTERNAL_ERROR_EXIT_CODE: i32 = -178;
 
 /// An action that is being awaited on and last known state.
 struct AwaitedAction {
@@ -256,6 +252,8 @@ impl SimpleSchedulerImpl {
             Some(running_action) => {
                 let mut awaited_action = running_action.action;
                 let send_result = if awaited_action.attempts >= self.max_job_retries {
+                    let mut default_action_result = ActionResult::default();
+                    default_action_result.execution_metadata.worker = format!("{}", worker_id);
                     Arc::make_mut(&mut awaited_action.current_state).stage = ActionStage::Error((
                         awaited_action.last_error.unwrap_or_else(|| {
                             make_err!(
@@ -263,28 +261,7 @@ impl SimpleSchedulerImpl {
                                 "Job cancelled because it attempted to execute too many times and failed"
                             )
                         }),
-                        ActionResult {
-                            output_files: Default::default(),
-                            output_folders: Default::default(),
-                            output_directory_symlinks: Default::default(),
-                            output_file_symlinks: Default::default(),
-                            exit_code: INTERNAL_ERROR_EXIT_CODE,
-                            stdout_digest: DigestInfo::empty_digest(),
-                            stderr_digest: DigestInfo::empty_digest(),
-                            execution_metadata: ExecutionMetadata {
-                                worker: format!("{}", worker_id),
-                                queued_timestamp: SystemTime::UNIX_EPOCH,
-                                worker_start_timestamp: SystemTime::UNIX_EPOCH,
-                                worker_completed_timestamp: SystemTime::UNIX_EPOCH,
-                                input_fetch_start_timestamp: SystemTime::UNIX_EPOCH,
-                                input_fetch_completed_timestamp: SystemTime::UNIX_EPOCH,
-                                execution_start_timestamp: SystemTime::UNIX_EPOCH,
-                                execution_completed_timestamp: SystemTime::UNIX_EPOCH,
-                                output_upload_start_timestamp: SystemTime::UNIX_EPOCH,
-                                output_upload_completed_timestamp: SystemTime::UNIX_EPOCH,
-                            },
-                            server_logs: Default::default(),
-                        },
+                        default_action_result,
                     ));
                     awaited_action.notify_channel.send(awaited_action.current_state.clone())
                     // Do not put the action back in the queue here, as this action attempted to run too many
@@ -514,7 +491,7 @@ impl SimpleSchedulerImpl {
 /// should be held in this struct.
 pub struct SimpleScheduler {
     inner: Arc<Mutex<SimpleSchedulerImpl>>,
-    platform_property_manager: PlatformPropertyManager,
+    platform_property_manager: Arc<PlatformPropertyManager>,
     task_worker_matching_future: JoinHandle<()>,
 }
 
@@ -537,12 +514,12 @@ impl SimpleScheduler {
         scheduler_cfg: &config::schedulers::SimpleScheduler,
         on_matching_engine_run: F,
     ) -> Self {
-        let platform_property_manager = PlatformPropertyManager::new(
+        let platform_property_manager = Arc::new(PlatformPropertyManager::new(
             scheduler_cfg
                 .supported_platform_properties
                 .clone()
                 .unwrap_or(HashMap::new()),
-        );
+        ));
 
         let mut worker_timeout_s = scheduler_cfg.worker_timeout_s;
         if worker_timeout_s == 0 {
@@ -613,8 +590,8 @@ impl SimpleScheduler {
 
 #[async_trait]
 impl ActionScheduler for SimpleScheduler {
-    fn get_platform_property_manager(&self) -> &PlatformPropertyManager {
-        &self.platform_property_manager
+    async fn get_platform_property_manager(&self, _instance_name: &str) -> Result<Arc<PlatformPropertyManager>, Error> {
+        Ok(self.platform_property_manager.clone())
     }
 
     async fn add_action(&self, action_info: ActionInfo) -> Result<watch::Receiver<Arc<ActionState>>, Error> {
@@ -626,7 +603,7 @@ impl ActionScheduler for SimpleScheduler {
 #[async_trait]
 impl WorkerScheduler for SimpleScheduler {
     fn get_platform_property_manager(&self) -> &PlatformPropertyManager {
-        &self.platform_property_manager
+        self.platform_property_manager.as_ref()
     }
 
     async fn add_worker(&self, worker: Worker) -> Result<(), Error> {

--- a/cas/scheduler/tests/action_messages_test.rs
+++ b/cas/scheduler/tests/action_messages_test.rs
@@ -108,6 +108,7 @@ mod action_messages_tests {
                 digest: DigestInfo::new([0u8; 32], 0),
                 salt: 0,
             },
+            skip_cache_lookup: true,
         });
         let lowest_priority_action = Arc::new(ActionInfo {
             instance_name: INSTANCE_NAME.to_string(),
@@ -124,6 +125,7 @@ mod action_messages_tests {
                 digest: DigestInfo::new([1u8; 32], 0),
                 salt: 0,
             },
+            skip_cache_lookup: true,
         });
         let mut action_map = BTreeMap::<Arc<ActionInfo>, ()>::new();
         action_map.insert(lowest_priority_action.clone(), ());
@@ -156,6 +158,7 @@ mod action_messages_tests {
                 digest: DigestInfo::new([0u8; 32], 0),
                 salt: 0,
             },
+            skip_cache_lookup: true,
         });
         let current_action = Arc::new(ActionInfo {
             instance_name: INSTANCE_NAME.to_string(),
@@ -172,6 +175,7 @@ mod action_messages_tests {
                 digest: DigestInfo::new([1u8; 32], 0),
                 salt: 0,
             },
+            skip_cache_lookup: true,
         });
         let mut action_map = BTreeMap::<Arc<ActionInfo>, ()>::new();
         action_map.insert(current_action.clone(), ());

--- a/cas/scheduler/tests/simple_scheduler_test.rs
+++ b/cas/scheduler/tests/simple_scheduler_test.rs
@@ -21,7 +21,7 @@ use tokio::sync::{mpsc, watch};
 
 use action_messages::{
     ActionInfo, ActionInfoHashKey, ActionResult, ActionStage, ActionState, DirectoryInfo, ExecutionMetadata, FileInfo,
-    NameOrPath, SymlinkInfo,
+    NameOrPath, SymlinkInfo, INTERNAL_ERROR_EXIT_CODE,
 };
 use common::DigestInfo;
 use config;
@@ -32,7 +32,7 @@ use proto::com::github::allada::turbo_cache::remote_execution::{
     update_for_worker, ConnectionResult, StartExecute, UpdateForWorker,
 };
 use scheduler::{ActionScheduler, WorkerScheduler};
-use simple_scheduler::{SimpleScheduler, INTERNAL_ERROR_EXIT_CODE};
+use simple_scheduler::SimpleScheduler;
 use worker::{Worker, WorkerId};
 
 const INSTANCE_NAME: &str = "foobar_instance_name";
@@ -53,6 +53,7 @@ fn make_base_action_info(insert_timestamp: SystemTime) -> ActionInfo {
             digest: DigestInfo::new([0u8; 32], 0),
             salt: 0,
         },
+        skip_cache_lookup: true,
     }
 }
 

--- a/cas/worker/tests/local_worker_test.rs
+++ b/cas/worker/tests/local_worker_test.rs
@@ -209,6 +209,7 @@ mod local_worker_tests {
                 digest: action_digest.clone(),
                 salt: SALT,
             },
+            skip_cache_lookup: true,
         };
 
         {

--- a/config/schedulers.rs
+++ b/config/schedulers.rs
@@ -16,12 +16,13 @@ use std::collections::HashMap;
 
 use serde::Deserialize;
 
-use serde_utils::convert_numeric_with_shellexpand;
+use serde_utils::{convert_numeric_with_shellexpand, convert_string_with_shellexpand};
 
 #[allow(non_camel_case_types)]
 #[derive(Deserialize, Debug)]
 pub enum SchedulerConfig {
     simple(SimpleScheduler),
+    grpc(GrpcScheduler),
 }
 
 /// When the scheduler matches tasks to workers that are capable of running
@@ -107,4 +108,15 @@ pub struct SimpleScheduler {
     /// The strategy used to assign workers jobs.
     #[serde(default)]
     pub allocation_strategy: WorkerAllocationStrategy,
+}
+
+/// A scheduler that simply forwards requests to an upstream scheduler.  This
+/// is useful to use when doing some kind of local action cache or CAS away from
+/// the main cluster of workers.  In general, it's more efficient to point the
+/// build at the main scheduler directly though.
+#[derive(Deserialize, Debug, Default)]
+pub struct GrpcScheduler {
+    /// The upstream scheduler to forward requests to.
+    #[serde(deserialize_with = "convert_string_with_shellexpand")]
+    pub endpoint: String,
 }


### PR DESCRIPTION
This implements an ActionScheduler that is able to forward to an upstream GrpcScheduler.  This allows proxying scheduler tasks from one instance to another.  This is useful when combined with a CacheLookupScheduler.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/allada/turbo-cache/160)
<!-- Reviewable:end -->
