### PR TITLE
Implementation of a cache lookup scheduler

### DIFF
--- a/cas/cas_main.rs
+++ b/cas/cas_main.rs
@@ -105,7 +105,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut worker_schedulers = HashMap::new();
     if let Some(schedulers_cfg) = cfg.schedulers {
         for (name, scheduler_cfg) in schedulers_cfg {
-            let (maybe_action_scheduler, maybe_worker_scheduler) = scheduler_factory(&scheduler_cfg)
+            let (maybe_action_scheduler, maybe_worker_scheduler) = scheduler_factory(&scheduler_cfg, &store_manager)
                 .await
                 .err_tip(|| format!("Failed to create scheduler '{}'", name))?;
             if let Some(action_scheduler) = maybe_action_scheduler {

--- a/cas/grpc_service/execution_server.rs
+++ b/cas/grpc_service/execution_server.rs
@@ -188,9 +188,12 @@ impl ExecutionServer {
             .build_action_info(instance_name, digest, &action, priority, execute_req.skip_cache_lookup)
             .await?;
 
+        // Warning: This name is ignored by GrpcScheduler, so don't use it for
+        //          operations mapping here...
+        let name = format!("{:X}", thread_rng().gen::<u128>());
         let rx = instance_info
             .scheduler
-            .add_action(action_info)
+            .add_action(name, action_info)
             .await
             .err_tip(|| "Failed to schedule task")?;
 

--- a/cas/grpc_service/tests/worker_api_server_test.rs
+++ b/cas/grpc_service/tests/worker_api_server_test.rs
@@ -291,7 +291,10 @@ pub mod execution_response_tests {
             },
             skip_cache_lookup: true,
         };
-        let mut client_action_state_receiver = test_context.scheduler.add_action(action_info).await?;
+        let mut client_action_state_receiver = test_context
+            .scheduler
+            .add_action("name".to_string(), action_info)
+            .await?;
 
         let mut server_logs = HashMap::new();
         server_logs.insert(

--- a/cas/scheduler/BUILD
+++ b/cas/scheduler/BUILD
@@ -32,6 +32,40 @@ rust_library(
 )
 
 rust_library(
+    name = "mock_scheduler",
+    testonly = True,
+    srcs = ["tests/utils/mock_scheduler.rs"],
+    visibility = [
+        "//cas:__pkg__",
+        "//cas:__subpackages__",
+    ],
+    proc_macro_deps = ["@crate_index//:async-trait"],
+    deps = [
+        ":action_messages",
+        ":platform_property_manager",
+        ":scheduler",
+        "//util:error",
+        "@crate_index//:tokio",
+    ],
+)
+
+rust_library(
+    name = "scheduler_utils",
+    testonly = True,
+    srcs = ["tests/utils/scheduler_utils.rs"],
+    visibility = [
+        "//cas:__pkg__",
+        "//cas:__subpackages__",
+    ],
+    proc_macro_deps = ["@crate_index//:async-trait"],
+    deps = [
+        ":action_messages",
+        ":platform_property_manager",
+        "//util:common",
+    ],
+)
+
+rust_library(
     name = "simple_scheduler",
     srcs = ["simple_scheduler.rs"],
     visibility = [
@@ -50,8 +84,57 @@ rust_library(
         "@crate_index//:parking_lot",
         "@crate_index//:futures",
         "@crate_index//:lru",
-        "@crate_index//:rand",
         "@crate_index//:tokio",
+    ],
+)
+
+rust_library(
+    name = "cache_lookup_scheduler",
+    srcs = ["cache_lookup_scheduler.rs"],
+    visibility = [
+        "//cas:__pkg__",
+        "//cas:__subpackages__",
+    ],
+    proc_macro_deps = ["@crate_index//:async-trait"],
+    deps = [
+        ":action_messages",
+        ":platform_property_manager",
+        ":scheduler",
+        ":worker",
+        "//cas/store",
+        "//cas/store:ac_utils",
+        "//cas/store:grpc_store",
+        "//config",
+        "//proto",
+        "//util:common",
+        "//util:error",
+        "@crate_index//:futures",
+        "@crate_index//:tonic",
+        "@crate_index//:tokio",
+        "@crate_index//:tokio-stream",
+    ],
+)
+
+rust_test(
+    name = "cache_lookup_scheduler_test",
+    srcs = ["tests/cache_lookup_scheduler_test.rs"],
+    deps = [
+        ":action_messages",
+        ":cache_lookup_scheduler",
+        ":mock_scheduler",
+        ":platform_property_manager",
+        ":scheduler",
+        ":scheduler_utils",
+        "//cas/store",
+        "//cas/store:memory_store",
+        "//config",
+        "//proto",
+        "//util:common",
+        "//util:error",
+        "@crate_index//:pretty_assertions",
+        "@crate_index//:prost",
+        "@crate_index//:tokio",
+        "@crate_index//:tokio-stream",
     ],
 )
 
@@ -85,9 +168,11 @@ rust_library(
         "//cas:__subpackages__",
     ],
     deps = [
+        ":cache_lookup_scheduler",
         ":grpc_scheduler",
         ":scheduler",
         ":simple_scheduler",
+        "//cas/store",
         "//config",
         "//util:error",
         "@crate_index//:futures",
@@ -155,6 +240,7 @@ rust_test(
         ":action_messages",
         ":platform_property_manager",
         ":scheduler",
+        ":scheduler_utils",
         ":simple_scheduler",
         ":worker",
         "//config",

--- a/cas/scheduler/cache_lookup_scheduler.rs
+++ b/cas/scheduler/cache_lookup_scheduler.rs
@@ -1,0 +1,183 @@
+// Copyright 2023 The Turbo Cache Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::pin::Pin;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use futures::stream::{FuturesUnordered, StreamExt};
+use tokio::sync::watch;
+use tokio_stream::wrappers::WatchStream;
+use tonic::Request;
+
+use ac_utils::get_and_decode_digest;
+use action_messages::{ActionInfo, ActionResult, ActionStage, ActionState};
+use common::DigestInfo;
+use error::Error;
+use grpc_store::GrpcStore;
+use platform_property_manager::PlatformPropertyManager;
+use proto::build::bazel::remote::execution::v2::{
+    ActionResult as ProtoActionResult, FindMissingBlobsRequest, GetActionResultRequest,
+};
+use scheduler::ActionScheduler;
+use store::Store;
+
+pub struct CacheLookupScheduler {
+    /// A reference to the CAS which is used to validate all the outputs of a
+    /// cached ActionResult still exist.
+    cas_store: Arc<dyn Store>,
+    /// A reference to the AC to find existing actions in.
+    ac_store: Arc<dyn Store>,
+    /// The "real" scheduler to use to perform actions if they were not found
+    /// in the action cache.
+    action_scheduler: Arc<dyn ActionScheduler>,
+}
+
+async fn get_action_from_store(
+    ac_store: Arc<dyn Store>,
+    action_digest: &DigestInfo,
+    instance_name: String,
+) -> Option<ProtoActionResult> {
+    // If we are a GrpcStore we shortcut here, as this is a special store.
+    let any_store = ac_store.clone().as_any();
+    let maybe_grpc_store = any_store.downcast_ref::<Arc<GrpcStore>>();
+    if let Some(grpc_store) = maybe_grpc_store {
+        let action_result_request = GetActionResultRequest {
+            instance_name,
+            action_digest: Some(action_digest.into()),
+            inline_stdout: false,
+            inline_stderr: false,
+            inline_output_files: Vec::new(),
+        };
+        grpc_store
+            .get_action_result(Request::new(action_result_request))
+            .await
+            .map(|response| response.into_inner())
+            .ok()
+    } else {
+        get_and_decode_digest::<ProtoActionResult>(Pin::new(ac_store.as_ref()), action_digest)
+            .await
+            .ok()
+    }
+}
+
+async fn validate_outputs_exist(
+    cas_store: Arc<dyn Store>,
+    action_result: &ProtoActionResult,
+    instance_name: String,
+) -> bool {
+    // Verify that output_files and output_directories are available in the cas.
+    let required_digests = action_result
+        .output_files
+        .iter()
+        .filter_map(|output_file| output_file.digest.clone())
+        .chain(
+            action_result
+                .output_directories
+                .iter()
+                .filter_map(|output_directory| output_directory.tree_digest.clone()),
+        )
+        .collect();
+
+    // If the CAS is a GrpcStore store we can check all the digests in one message.
+    let any_store = cas_store.clone().as_any();
+    let maybe_grpc_store = any_store.downcast_ref::<Arc<GrpcStore>>();
+    if let Some(grpc_store) = maybe_grpc_store {
+        grpc_store
+            .find_missing_blobs(Request::new(FindMissingBlobsRequest {
+                instance_name,
+                blob_digests: required_digests,
+            }))
+            .await
+            .is_ok_and(|find_result| find_result.into_inner().missing_blob_digests.is_empty())
+    } else {
+        let cas_pin = Pin::new(cas_store.as_ref());
+        required_digests
+            .into_iter()
+            .map(|digest| async move { cas_pin.has(DigestInfo::try_from(digest)?).await })
+            .collect::<FuturesUnordered<_>>()
+            .all(|result| async { result.is_ok_and(|result| result.is_some()) })
+            .await
+    }
+}
+
+impl CacheLookupScheduler {
+    pub fn new(
+        cas_store: Arc<dyn Store>,
+        ac_store: Arc<dyn Store>,
+        action_scheduler: Arc<dyn ActionScheduler>,
+    ) -> Result<Self, Error> {
+        Ok(Self {
+            cas_store,
+            ac_store,
+            action_scheduler,
+        })
+    }
+}
+
+#[async_trait]
+impl ActionScheduler for CacheLookupScheduler {
+    async fn get_platform_property_manager(&self, instance_name: &str) -> Result<Arc<PlatformPropertyManager>, Error> {
+        self.action_scheduler.get_platform_property_manager(instance_name).await
+    }
+
+    async fn add_action(
+        &self,
+        name: String,
+        action_info: ActionInfo,
+    ) -> Result<watch::Receiver<Arc<ActionState>>, Error> {
+        if action_info.skip_cache_lookup {
+            // Cache lookup skipped, forward to the upstream.
+            return self.action_scheduler.add_action(name, action_info).await;
+        }
+        let action_digest = action_info.digest();
+        let mut current_state = Arc::new(ActionState {
+            name: name.clone(),
+            stage: ActionStage::CacheCheck,
+            action_digest: *action_digest,
+        });
+        let (tx, rx) = watch::channel(current_state.clone());
+        let ac_store = self.ac_store.clone();
+        let cas_store = self.cas_store.clone();
+        let action_scheduler = self.action_scheduler.clone();
+        tokio::spawn(async move {
+            let instance_name = action_info.instance_name.to_string();
+            if let Some(proto_action_result) =
+                get_action_from_store(ac_store, &current_state.action_digest, instance_name.clone()).await
+            {
+                if validate_outputs_exist(cas_store, &proto_action_result, instance_name).await {
+                    // Found in the cache, return the result immediately.
+                    Arc::make_mut(&mut current_state).stage = ActionStage::CompletedFromCache(proto_action_result);
+                    let _ = tx.send(current_state);
+                    return;
+                }
+            }
+            // Not in cache, forward to upstream and proxy state.
+            let mut watch_stream = match action_scheduler.add_action(name, action_info).await {
+                Ok(rx) => WatchStream::new(rx),
+                Err(err) => {
+                    Arc::make_mut(&mut current_state).stage = ActionStage::Error((err, ActionResult::default()));
+                    let _ = tx.send(current_state);
+                    return;
+                }
+            };
+            while let Some(action_state) = watch_stream.next().await {
+                if tx.send(action_state).is_err() {
+                    break;
+                }
+            }
+        });
+        Ok(rx)
+    }
+}

--- a/cas/scheduler/default_scheduler_factory.rs
+++ b/cas/scheduler/default_scheduler_factory.rs
@@ -17,16 +17,19 @@ use std::sync::Arc;
 
 use futures::Future;
 
+use cache_lookup_scheduler::CacheLookupScheduler;
 use config::schedulers::SchedulerConfig;
-use error::Error;
+use error::{Error, ResultExt};
 use grpc_scheduler::GrpcScheduler;
 use scheduler::{ActionScheduler, WorkerScheduler};
 use simple_scheduler::SimpleScheduler;
+use store::StoreManager;
 
 pub type SchedulerFactoryResults = (Option<Arc<dyn ActionScheduler>>, Option<Arc<dyn WorkerScheduler>>);
 
 pub fn scheduler_factory<'a>(
     scheduler_type_cfg: &'a SchedulerConfig,
+    store_manager: &'a StoreManager,
 ) -> Pin<Box<dyn Future<Output = Result<SchedulerFactoryResults, Error>> + 'a>> {
     Box::pin(async move {
         let scheduler: SchedulerFactoryResults = match scheduler_type_cfg {
@@ -34,7 +37,22 @@ pub fn scheduler_factory<'a>(
                 let scheduler = Arc::new(SimpleScheduler::new(&config));
                 (Some(scheduler.clone()), Some(scheduler))
             }
-            SchedulerConfig::grpc(config) => (Some(Arc::new(GrpcScheduler::new(&config).await?)), None),
+            SchedulerConfig::grpc(config) => (Some(Arc::new(GrpcScheduler::new(config).await?)), None),
+            SchedulerConfig::cache_lookup(config) => {
+                let cas_store = store_manager
+                    .get_store(&config.cas_store)
+                    .err_tip(|| format!("'cas_store': '{}' does not exist", config.cas_store))?;
+                let ac_store = store_manager
+                    .get_store(&config.ac_store)
+                    .err_tip(|| format!("'ac_store': '{}' does not exist", config.ac_store))?;
+                let (action_scheduler, worker_scheduler) = scheduler_factory(&config.scheduler, store_manager).await?;
+                let cache_lookup_scheduler = Arc::new(CacheLookupScheduler::new(
+                    cas_store,
+                    ac_store,
+                    action_scheduler.err_tip(|| "Nested scheduler is not an action scheduler")?,
+                )?);
+                (Some(cache_lookup_scheduler), worker_scheduler)
+            }
         };
         Ok(scheduler)
     })

--- a/cas/scheduler/grpc_scheduler.rs
+++ b/cas/scheduler/grpc_scheduler.rs
@@ -82,7 +82,11 @@ impl ActionScheduler for GrpcScheduler {
         Ok(platform_property_manager)
     }
 
-    async fn add_action(&self, action_info: ActionInfo) -> Result<watch::Receiver<Arc<ActionState>>, Error> {
+    async fn add_action(
+        &self,
+        _name: String,
+        action_info: ActionInfo,
+    ) -> Result<watch::Receiver<Arc<ActionState>>, Error> {
         let execution_policy = if action_info.priority == DEFAULT_EXECUTION_PRIORITY {
             None
         } else {

--- a/cas/scheduler/scheduler.rs
+++ b/cas/scheduler/scheduler.rs
@@ -30,7 +30,11 @@ pub trait ActionScheduler: Sync + Send + Unpin {
     async fn get_platform_property_manager(&self, instance_name: &str) -> Result<Arc<PlatformPropertyManager>, Error>;
 
     /// Adds an action to the scheduler for remote execution.
-    async fn add_action(&self, action_info: ActionInfo) -> Result<watch::Receiver<Arc<ActionState>>, Error>;
+    async fn add_action(
+        &self,
+        name: String,
+        action_info: ActionInfo,
+    ) -> Result<watch::Receiver<Arc<ActionState>>, Error>;
 }
 
 /// WorkerScheduler interface is responsible for interactions between the scheduler

--- a/cas/scheduler/tests/cache_lookup_scheduler_test.rs
+++ b/cas/scheduler/tests/cache_lookup_scheduler_test.rs
@@ -1,0 +1,164 @@
+// Copyright 2023 The Turbo Cache Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::UNIX_EPOCH;
+
+use prost::Message;
+use tokio::{self, join, sync::watch};
+use tokio_stream::wrappers::WatchStream;
+use tokio_stream::StreamExt;
+
+use action_messages::{ActionResult, ActionStage, ActionState, DirectoryInfo};
+use cache_lookup_scheduler::CacheLookupScheduler;
+use common::DigestInfo;
+use error::{Error, ResultExt};
+use memory_store::MemoryStore;
+use mock_scheduler::MockActionScheduler;
+use platform_property_manager::PlatformPropertyManager;
+use proto::build::bazel::remote::execution::v2::ActionResult as ProtoActionResult;
+use scheduler::ActionScheduler;
+use scheduler_utils::{make_base_action_info, INSTANCE_NAME};
+use store::Store;
+
+struct TestContext {
+    mock_scheduler: Arc<MockActionScheduler>,
+    ac_store: Arc<dyn Store>,
+    cache_scheduler: CacheLookupScheduler,
+}
+
+fn make_cache_scheduler() -> Result<TestContext, Error> {
+    let mock_scheduler = Arc::new(MockActionScheduler::new());
+    let cas_store = Arc::new(MemoryStore::new(&config::stores::MemoryStore::default()));
+    let ac_store = Arc::new(MemoryStore::new(&config::stores::MemoryStore::default()));
+    let cache_scheduler = CacheLookupScheduler::new(cas_store, ac_store.clone(), mock_scheduler.clone())?;
+    Ok(TestContext {
+        mock_scheduler,
+        ac_store,
+        cache_scheduler,
+    })
+}
+
+#[cfg(test)]
+mod cache_lookup_scheduler_tests {
+    use super::*;
+    use pretty_assertions::assert_eq; // Must be declared in every module.
+
+    #[tokio::test]
+    async fn platform_property_manager_call_passed() -> Result<(), Error> {
+        let context = make_cache_scheduler()?;
+        let platform_property_manager = Arc::new(PlatformPropertyManager::new(HashMap::new()));
+        let instance_name = INSTANCE_NAME.to_string();
+        let (actual_manager, actual_instance_name) = join!(
+            context.cache_scheduler.get_platform_property_manager(&instance_name),
+            context
+                .mock_scheduler
+                .expect_get_platform_property_manager(Ok(platform_property_manager.clone())),
+        );
+        assert_eq!(Arc::as_ptr(&platform_property_manager), Arc::as_ptr(&actual_manager?));
+        assert_eq!(instance_name, actual_instance_name);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn add_action_does_cache_lookup() -> Result<(), Error> {
+        let context = make_cache_scheduler()?;
+        let action_info = make_base_action_info(UNIX_EPOCH);
+        let action_result = ProtoActionResult::from(ActionResult::default());
+        let store_pin = Pin::new(context.ac_store.as_ref());
+        store_pin
+            .update_oneshot(
+                action_info.unique_qualifier.digest,
+                action_result.encode_to_vec().into(),
+            )
+            .await?;
+        let watch_channel = context
+            .cache_scheduler
+            .add_action("name".to_string(), action_info.clone())
+            .await?;
+        let mut watch_stream = WatchStream::new(watch_channel);
+        if watch_stream.next().await.err_tip(|| "Getting initial state")?.stage != ActionStage::CacheCheck {
+            panic!("Not performing a cache check");
+        }
+        let cached_action_state = watch_stream.next().await.err_tip(|| "Getting post-cache result")?;
+        let ActionStage::CompletedFromCache(proto_action_result) = cached_action_state.stage.clone() else {
+            panic!("Did not complete from cache");
+        };
+        assert_eq!(action_info.unique_qualifier.digest, cached_action_state.action_digest);
+        assert_eq!(action_result, proto_action_result);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn add_action_validates_outputs() -> Result<(), Error> {
+        let context = make_cache_scheduler()?;
+        let action_info = make_base_action_info(UNIX_EPOCH);
+        let mut action_result = ActionResult::default();
+        action_result.output_folders.push(DirectoryInfo {
+            path: "".to_string(),
+            tree_digest: DigestInfo {
+                size_bytes: 1,
+                packed_hash: [8; 32],
+            },
+        });
+        let action_result = ProtoActionResult::from(action_result);
+        let store_pin = Pin::new(context.ac_store.as_ref());
+        store_pin
+            .update_oneshot(
+                action_info.unique_qualifier.digest,
+                action_result.encode_to_vec().into(),
+            )
+            .await?;
+        let (_forward_watch_channel_tx, forward_watch_channel_rx) = watch::channel(Arc::new(ActionState {
+            name: "".to_string(),
+            action_digest: action_info.unique_qualifier.digest,
+            stage: ActionStage::Queued,
+        }));
+        let _ = join!(
+            context.cache_scheduler.add_action("name".to_string(), action_info),
+            context.mock_scheduler.expect_add_action(Ok(forward_watch_channel_rx))
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn add_action_handles_skip_cache() -> Result<(), Error> {
+        let context = make_cache_scheduler()?;
+        let action_info = make_base_action_info(UNIX_EPOCH);
+        let action_result = ProtoActionResult::from(ActionResult::default());
+        let store_pin = Pin::new(context.ac_store.as_ref());
+        store_pin
+            .update_oneshot(
+                action_info.unique_qualifier.digest,
+                action_result.encode_to_vec().into(),
+            )
+            .await?;
+        let (_forward_watch_channel_tx, forward_watch_channel_rx) = watch::channel(Arc::new(ActionState {
+            name: "".to_string(),
+            action_digest: action_info.unique_qualifier.digest,
+            stage: ActionStage::Queued,
+        }));
+        let mut skip_cache_action = action_info.clone();
+        skip_cache_action.skip_cache_lookup = true;
+        let _ = join!(
+            context
+                .cache_scheduler
+                .add_action("name".to_string(), skip_cache_action),
+            context.mock_scheduler.expect_add_action(Ok(forward_watch_channel_rx))
+        );
+        Ok(())
+    }
+}

--- a/cas/scheduler/tests/utils/mock_scheduler.rs
+++ b/cas/scheduler/tests/utils/mock_scheduler.rs
@@ -1,0 +1,128 @@
+// Copyright 2023 The Turbo Cache Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use tokio::sync::{mpsc, watch, Mutex};
+
+use action_messages::{ActionInfo, ActionState};
+use error::{make_input_err, Error};
+use platform_property_manager::PlatformPropertyManager;
+use scheduler::ActionScheduler;
+
+#[allow(clippy::large_enum_variant)]
+enum ActionSchedulerCalls {
+    GetPlatformPropertyManager(String),
+    AddAction((String, ActionInfo)),
+}
+
+enum ActionSchedulerReturns {
+    GetPlatformPropertyManager(Result<Arc<PlatformPropertyManager>, Error>),
+    AddAction(Result<watch::Receiver<Arc<ActionState>>, Error>),
+}
+
+pub struct MockActionScheduler {
+    rx_call: Mutex<mpsc::UnboundedReceiver<ActionSchedulerCalls>>,
+    tx_call: mpsc::UnboundedSender<ActionSchedulerCalls>,
+
+    rx_resp: Mutex<mpsc::UnboundedReceiver<ActionSchedulerReturns>>,
+    tx_resp: mpsc::UnboundedSender<ActionSchedulerReturns>,
+}
+
+impl Default for MockActionScheduler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MockActionScheduler {
+    pub fn new() -> Self {
+        let (tx_call, rx_call) = mpsc::unbounded_channel();
+        let (tx_resp, rx_resp) = mpsc::unbounded_channel();
+        Self {
+            rx_call: Mutex::new(rx_call),
+            tx_call,
+            rx_resp: Mutex::new(rx_resp),
+            tx_resp,
+        }
+    }
+
+    pub async fn expect_get_platform_property_manager(
+        &self,
+        result: Result<Arc<PlatformPropertyManager>, Error>,
+    ) -> String {
+        let mut rx_call_lock = self.rx_call.lock().await;
+        let ActionSchedulerCalls::GetPlatformPropertyManager(req) = rx_call_lock
+            .recv()
+            .await
+            .expect("Could not receive msg in mpsc") else {
+                panic!("Got incorrect call waiting for get_platform_property_manager")
+            };
+        self.tx_resp
+            .send(ActionSchedulerReturns::GetPlatformPropertyManager(result))
+            .map_err(|_| make_input_err!("Could not send request to mpsc"))
+            .unwrap();
+        req
+    }
+
+    pub async fn expect_add_action(
+        &self,
+        result: Result<watch::Receiver<Arc<ActionState>>, Error>,
+    ) -> (String, ActionInfo) {
+        let mut rx_call_lock = self.rx_call.lock().await;
+        let ActionSchedulerCalls::AddAction(req) = rx_call_lock
+            .recv()
+            .await
+            .expect("Could not receive msg in mpsc") else {
+                panic!("Got incorrect call waiting for get_platform_property_manager")
+            };
+        self.tx_resp
+            .send(ActionSchedulerReturns::AddAction(result))
+            .map_err(|_| make_input_err!("Could not send request to mpsc"))
+            .unwrap();
+        req
+    }
+}
+
+#[async_trait]
+impl ActionScheduler for MockActionScheduler {
+    async fn get_platform_property_manager(&self, instance_name: &str) -> Result<Arc<PlatformPropertyManager>, Error> {
+        self.tx_call
+            .send(ActionSchedulerCalls::GetPlatformPropertyManager(
+                instance_name.to_string(),
+            ))
+            .expect("Could not send request to mpsc");
+        let mut rx_resp_lock = self.rx_resp.lock().await;
+        match rx_resp_lock.recv().await.expect("Could not receive msg in mpsc") {
+            ActionSchedulerReturns::GetPlatformPropertyManager(result) => result,
+            _ => panic!("Expected get_platform_property_manager return value"),
+        }
+    }
+
+    async fn add_action(
+        &self,
+        name: String,
+        action_info: ActionInfo,
+    ) -> Result<watch::Receiver<Arc<ActionState>>, Error> {
+        self.tx_call
+            .send(ActionSchedulerCalls::AddAction((name, action_info)))
+            .expect("Could not send request to mpsc");
+        let mut rx_resp_lock = self.rx_resp.lock().await;
+        match rx_resp_lock.recv().await.expect("Could not receive msg in mpsc") {
+            ActionSchedulerReturns::AddAction(result) => result,
+            _ => panic!("Expected add_action return value"),
+        }
+    }
+}

--- a/cas/scheduler/tests/utils/scheduler_utils.rs
+++ b/cas/scheduler/tests/utils/scheduler_utils.rs
@@ -1,0 +1,42 @@
+// Copyright 2023 The Turbo Cache Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use action_messages::{ActionInfo, ActionInfoHashKey};
+use common::DigestInfo;
+use platform_property_manager::PlatformProperties;
+
+pub const INSTANCE_NAME: &str = "foobar_instance_name";
+
+pub fn make_base_action_info(insert_timestamp: SystemTime) -> ActionInfo {
+    ActionInfo {
+        instance_name: INSTANCE_NAME.to_string(),
+        command_digest: DigestInfo::new([0u8; 32], 0),
+        input_root_digest: DigestInfo::new([0u8; 32], 0),
+        timeout: Duration::MAX,
+        platform_properties: PlatformProperties {
+            properties: HashMap::new(),
+        },
+        priority: 0,
+        load_timestamp: UNIX_EPOCH,
+        insert_timestamp,
+        unique_qualifier: ActionInfoHashKey {
+            digest: DigestInfo::new([0u8; 32], 0),
+            salt: 0,
+        },
+        skip_cache_lookup: false,
+    }
+}

--- a/config/BUILD
+++ b/config/BUILD
@@ -42,6 +42,7 @@ rust_library(
     name = "schedulers",
     srcs = ["schedulers.rs"],
     deps = [
+        ":stores",
         "//util:serde_utils",
         "@crate_index//:serde",
     ],

--- a/config/cas_server.rs
+++ b/config/cas_server.rs
@@ -17,10 +17,7 @@ use std::collections::HashMap;
 use serde::Deserialize;
 
 use serde_utils::{convert_numeric_with_shellexpand, convert_string_with_shellexpand};
-
-/// Name of the store. This type will be used when referencing a store
-/// in the `CasConfig::stores`'s map key.
-pub type StoreRefName = String;
+use stores::StoreRefName;
 
 /// Name of the scheduler. This type will be used when referencing a
 /// scheduler in the `CasConfig::schedulers`'s map key.

--- a/config/schedulers.rs
+++ b/config/schedulers.rs
@@ -17,12 +17,14 @@ use std::collections::HashMap;
 use serde::Deserialize;
 
 use serde_utils::{convert_numeric_with_shellexpand, convert_string_with_shellexpand};
+use stores::StoreRefName;
 
 #[allow(non_camel_case_types)]
 #[derive(Deserialize, Debug)]
 pub enum SchedulerConfig {
     simple(SimpleScheduler),
     grpc(GrpcScheduler),
+    cache_lookup(CacheLookupScheduler),
 }
 
 /// When the scheduler matches tasks to workers that are capable of running
@@ -119,4 +121,19 @@ pub struct GrpcScheduler {
     /// The upstream scheduler to forward requests to.
     #[serde(deserialize_with = "convert_string_with_shellexpand")]
     pub endpoint: String,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct CacheLookupScheduler {
+    /// The reference to the action cache store to use to returned cached
+    /// actions from rather than running them again.
+    pub ac_store: StoreRefName,
+
+    /// The reference to the CAS which contains the outputs from the cached
+    /// actions to verify that the outputs still exist before returning a
+    /// cached result.
+    pub cas_store: StoreRefName,
+
+    /// The nested scheduler to use if cache lookup fails.
+    pub scheduler: Box<SchedulerConfig>,
 }

--- a/config/stores.rs
+++ b/config/stores.rs
@@ -16,6 +16,10 @@ use serde::{Deserialize, Serialize};
 
 use serde_utils::{convert_numeric_with_shellexpand, convert_string_with_shellexpand};
 
+/// Name of the store. This type will be used when referencing a store
+/// in the `CasConfig::stores`'s map key.
+pub type StoreRefName = String;
+
 #[allow(non_camel_case_types)]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum StoreConfig {


### PR DESCRIPTION
This scheduler sits in front of another one and looks up actions in
the cache if requested before queueing them.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/allada/turbo-cache/161)
<!-- Reviewable:end -->
