### PR TITLE
Add is_empty to LenEntry

### DIFF
--- a/cas/store/filesystem_store.rs
+++ b/cas/store/filesystem_store.rs
@@ -254,6 +254,10 @@ impl LenEntry for FileEntryImpl {
         self.file_size as usize
     }
 
+    fn is_empty(&self) -> bool {
+        self.file_size == 0
+    }
+
     #[inline]
     async fn touch(&self) {
         let result = self

--- a/cas/store/memory_store.rs
+++ b/cas/store/memory_store.rs
@@ -41,6 +41,11 @@ impl LenEntry for BytesWrapper {
     fn len(&self) -> usize {
         Bytes::len(&self.0)
     }
+
+    #[inline]
+    fn is_empty(&self) -> bool {
+        Bytes::is_empty(&self.0)
+    }
 }
 
 pub struct MemoryStore {

--- a/cas/store/tests/filesystem_store_test.rs
+++ b/cas/store/tests/filesystem_store_test.rs
@@ -110,6 +110,10 @@ impl<Hooks: FileEntryHooks + 'static + Sync + Send> LenEntry for TestFileEntry<H
         self.inner.as_ref().unwrap().len()
     }
 
+    fn is_empty(&self) -> bool {
+        self.inner.as_ref().unwrap().is_empty()
+    }
+
     async fn touch(&self) {
         self.inner.as_ref().unwrap().touch().await
     }

--- a/util/tests/evicting_map_test.rs
+++ b/util/tests/evicting_map_test.rs
@@ -33,6 +33,11 @@ impl LenEntry for BytesWrapper {
     fn len(&self) -> usize {
         Bytes::len(&self.0)
     }
+
+    #[inline]
+    fn is_empty(&self) -> bool {
+        Bytes::is_empty(&self.0)
+    }
 }
 
 impl From<Bytes> for BytesWrapper {
@@ -272,7 +277,11 @@ mod evicting_map_tests {
         impl LenEntry for MockEntry {
             fn len(&self) -> usize {
                 // Note: We are not testing this functionality.
-                return 0;
+                0
+            }
+
+            fn is_empty(&self) -> bool {
+                unreachable!("We are not testing this functionality");
             }
 
             async fn touch(&self) {
@@ -318,8 +327,8 @@ mod evicting_map_tests {
         let existing_entry = evicting_map.get(&DigestInfo::try_new(HASH1, 0)?).await.unwrap();
         assert_eq!(existing_entry.data, DATA2);
 
-        assert_eq!(entry1.unref_called.load(Ordering::Relaxed), true);
-        assert_eq!(entry2.unref_called.load(Ordering::Relaxed), false);
+        assert!(entry1.unref_called.load(Ordering::Relaxed));
+        assert!(!entry2.unref_called.load(Ordering::Relaxed));
 
         Ok(())
     }


### PR DESCRIPTION
Since this clippy warning requires touching several files we handle it separately. Most remaining warnings should be self-contained enough that we can handle them on a file-by-file basis.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/allada/turbo-cache/163)
<!-- Reviewable:end -->
