### PR TITLE
Add support for backpressure from workers.

### DIFF
--- a/cas/scheduler/simple_scheduler.rs
+++ b/cas/scheduler/simple_scheduler.rs
@@ -127,16 +127,15 @@ impl Workers {
         assert!(matches!(awaited_action.current_state.stage, ActionStage::Queued));
         let action_properties = &awaited_action.action_info.platform_properties;
         let mut workers_iter = self.workers.iter_mut();
-        let workers_iter = match self.allocation_strategy {
-            // Use rfind to get the least recently used that satisfies the properties.
-            config::schedulers::WorkerAllocationStrategy::LeastRecentlyUsed => {
-                workers_iter.rfind(|(_, w)| action_properties.is_satisfied_by(&w.platform_properties))
-            }
-            // Use find to get the most recently used that satisfies the properties.
-            config::schedulers::WorkerAllocationStrategy::MostRecentlyUsed => {
-                workers_iter.find(|(_, w)| action_properties.is_satisfied_by(&w.platform_properties))
-            }
-        };
+        let workers_iter =
+            match self.allocation_strategy {
+                // Use rfind to get the least recently used that satisfies the properties.
+                config::schedulers::WorkerAllocationStrategy::LeastRecentlyUsed => workers_iter
+                    .rfind(|(_, w)| !w.is_paused && action_properties.is_satisfied_by(&w.platform_properties)),
+                // Use find to get the most recently used that satisfies the properties.
+                config::schedulers::WorkerAllocationStrategy::MostRecentlyUsed => workers_iter
+                    .find(|(_, w)| !w.is_paused && action_properties.is_satisfied_by(&w.platform_properties)),
+            };
         let worker_id = workers_iter.map(|(_, w)| &w.id);
         // We need to "touch" the worker to ensure it gets re-ordered in the LRUCache, since it was selected.
         if let Some(&worker_id) = worker_id {
@@ -247,10 +246,14 @@ impl SimpleSchedulerImpl {
         Ok(rx)
     }
 
-    fn retry_action(&mut self, action_info: &Arc<ActionInfo>, worker_id: &WorkerId) {
+    fn retry_action(&mut self, action_info: &Arc<ActionInfo>, worker_id: &WorkerId, due_to_backpressure: bool) {
         match self.active_actions.remove(action_info) {
             Some(running_action) => {
                 let mut awaited_action = running_action.action;
+                // Don't count a backpressure failure as an attempt for an action.
+                if due_to_backpressure {
+                    awaited_action.attempts -= 1;
+                }
                 let send_result = if awaited_action.attempts >= self.max_job_retries {
                     let mut default_action_result = ActionResult::default();
                     default_action_result.execution_metadata.worker = format!("{}", worker_id);
@@ -298,7 +301,7 @@ impl SimpleSchedulerImpl {
             // We create a temporary Vec to avoid doubt about a possible code
             // path touching the worker.running_action_infos elsewhere.
             for action_info in worker.running_action_infos.drain() {
-                self.retry_action(&action_info, &worker_id);
+                self.retry_action(&action_info, &worker_id, false);
             }
         }
         // Note: Calling this many time is very cheap, it'll only trigger `do_try_match` once.
@@ -390,6 +393,8 @@ impl SimpleSchedulerImpl {
             }
         };
 
+        let due_to_backpressure = err.code == Code::ResourceExhausted;
+
         if running_action.worker_id != *worker_id {
             log::error!(
                 "Got a result from a worker that should not be running the action, Removing worker. Expected worker {} got worker {}",
@@ -406,11 +411,18 @@ impl SimpleSchedulerImpl {
 
         // Clear this action from the current worker.
         if let Some(worker) = self.workers.workers.get_mut(worker_id) {
+            let was_paused = worker.is_paused;
+            // This unpauses, but since we're completing with an error, don't
+            // unpause unless all actions have completed.
             worker.complete_action(&action_info);
+            // Only pause if there's an action still waiting that will unpause.
+            if (was_paused || due_to_backpressure) && worker.has_actions() {
+                worker.is_paused = true;
+            }
         }
 
         // Re-queue the action or fail on max attempts.
-        self.retry_action(&action_info, &worker_id);
+        self.retry_action(&action_info, &worker_id, due_to_backpressure);
     }
 
     fn update_action(

--- a/cas/scheduler/worker.rs
+++ b/cas/scheduler/worker.rs
@@ -89,6 +89,9 @@ pub struct Worker {
     // Warning: Do not update this timestamp without updating the placement of the worker in
     // the LRUCache in the Workers struct.
     pub last_update_timestamp: WorkerTimestamp,
+
+    /// Whether the worker rejected the last action due to back pressure.
+    pub is_paused: bool,
 }
 
 impl Worker {
@@ -104,6 +107,7 @@ impl Worker {
             tx,
             running_action_infos: HashSet::new(),
             last_update_timestamp: timestamp,
+            is_paused: false,
         }
     }
 
@@ -148,7 +152,12 @@ impl Worker {
 
     pub fn complete_action(&mut self, action_info: &Arc<ActionInfo>) {
         self.running_action_infos.remove(action_info);
-        self.restore_platform_properties(&action_info.platform_properties)
+        self.restore_platform_properties(&action_info.platform_properties);
+        self.is_paused = false;
+    }
+
+    pub fn has_actions(&self) -> bool {
+        !self.running_action_infos.is_empty()
     }
 
     /// Reduces the platform properties available on the worker based on the platform properties provided.

--- a/cas/worker/tests/utils/local_worker_test_utils.rs
+++ b/cas/worker/tests/utils/local_worker_test_utils.rs
@@ -41,19 +41,10 @@ pub fn setup_grpc_stream() -> (HyperSender, Response<Streaming<UpdateForWorker>>
     (tx, Response::new(stream))
 }
 
-pub async fn setup_local_worker(platform_properties: HashMap<String, WrokerProperty>) -> TestContext {
+pub async fn setup_local_worker_with_config(local_worker_config: LocalWorkerConfig) -> TestContext {
     let mock_worker_api_client = MockWorkerApiClient::new();
     let mock_worker_api_client_clone = mock_worker_api_client.clone();
     let actions_manager = Arc::new(MockRunningActionsManager::new());
-    const ARBITRARY_LARGE_TIMEOUT: f32 = 10000.;
-    let local_worker_config = LocalWorkerConfig {
-        platform_properties,
-        worker_api_endpoint: EndpointConfig {
-            timeout: Some(ARBITRARY_LARGE_TIMEOUT),
-            ..Default::default()
-        },
-        ..Default::default()
-    };
     let worker = LocalWorker::new_with_connection_factory_and_actions_manager(
         Arc::new(local_worker_config),
         actions_manager.clone(),
@@ -75,6 +66,19 @@ pub async fn setup_local_worker(platform_properties: HashMap<String, WrokerPrope
 
         _drop_guard: drop_guard,
     }
+}
+
+pub async fn setup_local_worker(platform_properties: HashMap<String, WrokerProperty>) -> TestContext {
+    const ARBITRARY_LARGE_TIMEOUT: f32 = 10000.;
+    let local_worker_config = LocalWorkerConfig {
+        platform_properties,
+        worker_api_endpoint: EndpointConfig {
+            timeout: Some(ARBITRARY_LARGE_TIMEOUT),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    setup_local_worker_with_config(local_worker_config).await
 }
 
 pub struct TestContext {

--- a/config/cas_server.rs
+++ b/config/cas_server.rs
@@ -265,6 +265,16 @@ pub struct LocalWorkerConfig {
     /// and used to tell the scheduler to restrict what should be executed on this
     /// worker.
     pub platform_properties: HashMap<String, WrokerProperty>,
+
+    /// An optional script to run before every action is processed on the worker.
+    /// The value should be the full path to the script to execute and will pause
+    /// all actions on the worker if it returns an exit code other than 0.
+    /// If not set, then the worker will never pause and will continue to accept
+    /// jobs according to the scheduler configuration.
+    /// This is useful, for example, if the worker should not take any more
+    /// actions until there is enough resource available on the machine to
+    /// handle them.
+    pub precondition_script: Option<String>,
 }
 
 #[allow(non_camel_case_types)]


### PR DESCRIPTION
Our main issue is that some parts of our code base eat all of the RAM.  This is one of the mitigations against that.

This allows workers to be configured with minimum resource limits separately to the the platform properties.  This allows them to return a ResourceExhausted state which pauses the worker on the scheduler until an action has completed (if it has one).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/allada/turbo-cache/167)
<!-- Reviewable:end -->
