### PR TITLE
Removes needless overoptimization of strings for DigestInfo

### DIFF
--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "ec1aaea79db6c8962a1718248f7b28b82eb70a7dee255529ea671dfed22e58a2",
+  "checksum": "4f921e8c24fd74362f4fa660db203c02dfdc564ae44a23e8d4526d28aab7aafb",
   "crates": {
     "addr2line 0.20.0": {
       "name": "addr2line",
@@ -2499,10 +2499,6 @@
             {
               "id": "json5 0.4.1",
               "target": "json5"
-            },
-            {
-              "id": "lazy-init 0.5.1",
-              "target": "lazy_init"
             },
             {
               "id": "lazy_static 1.4.0",
@@ -5245,36 +5241,6 @@
         "version": "0.4.1"
       },
       "license": "ISC"
-    },
-    "lazy-init 0.5.1": {
-      "name": "lazy-init",
-      "version": "0.5.1",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/lazy-init/0.5.1/download",
-          "sha256": "9f40963626ac12dcaf92afc15e4c3db624858c92fd9f8ba2125eaada3ac2706f"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "lazy_init",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "lazy_init",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "edition": "2015",
-        "version": "0.5.1"
-      },
-      "license": "Apache-2.0/MIT"
     },
     "lazy_static 1.4.0": {
       "name": "lazy_static",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -486,7 +486,6 @@ dependencies = [
  "http",
  "hyper",
  "json5",
- "lazy-init",
  "lazy_static",
  "log",
  "lru",
@@ -994,12 +993,6 @@ dependencies = [
  "pest_derive",
  "serde",
 ]
-
-[[package]]
-name = "lazy-init"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f40963626ac12dcaf92afc15e4c3db624858c92fd9f8ba2125eaada3ac2706f"
 
 [[package]]
 name = "lazy_static"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ tokio = { version = "1.29.1", features = ["macros", "io-util", "fs", "rt-multi-t
 tokio-stream = { version = "0.1.14", features = ["fs", "sync"] }
 tokio-util = { version = "0.7.8", features = ["io", "io-util", "codec"] }
 tonic = { version = "0.9.2", features = ["gzip"] }
-lazy-init = "0.5.1"
 log = "0.4.19"
 env_logger = "0.10.0"
 serde = "1.0.167"

--- a/util/BUILD
+++ b/util/BUILD
@@ -24,7 +24,6 @@ rust_library(
         "//proto",
         "@crate_index//:bytes",
         "@crate_index//:hex",
-        "@crate_index//:lazy-init",
         "@crate_index//:log",
         "@crate_index//:prost",
         "@crate_index//:serde",


### PR DESCRIPTION
We make so many copies of DigestInfo and it's not trivial-copyable because of an optimization that adds around 40 bytes of data to each struct which tries to preserve the string representation of the digest when possible. This optimization seems to be pointless and likely ends up costing more than it saves.

On local testing, I found that the overhead of the LazyInit was slightly more than a single invocation of `.str()`. Since we usually only call `.str()` once per DigestInfo, it does not seem like a good idea to assume we would need the hex string more than once per struct.

There is also a significant chance this will give secondary optimizations because without this optimization the struct is trivially-copyable. This enables the optimizer to do even more clever tricks for inlining since it knows it does not need to touch the heap.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/allada/turbo-cache/174)
<!-- Reviewable:end -->
