### PR TITLE
Fix potential bug where scheduer could drop action and remove Arc

### DIFF
--- a/cas/grpc_service/tests/worker_api_server_test.rs
+++ b/cas/grpc_service/tests/worker_api_server_test.rs
@@ -365,7 +365,7 @@ pub mod execution_response_tests {
             // Ensure our client thinks we are executing.
             client_action_state_receiver.changed().await?;
             let action_state = client_action_state_receiver.borrow();
-            assert_eq!(action_state.as_ref().stage, ActionStage::Executing);
+            assert_eq!(action_state.stage, ActionStage::Executing);
         }
 
         // Now send the result of our execution to the scheduler.


### PR DESCRIPTION
In the code as it is written right now it is not possible for this to happen, but it could easily be implemented on the worker without needing to touch the scheduler code.

The case if the worker looked up the action in the cache and found a hit, it could return a result stating it was served from cache. In this event the scheduler would never flag the action as completed.
<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/allada/turbo-cache/179)
<!-- Reviewable:end -->
