### PR TITLE
Add optional sanitizer build configurations

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -35,3 +35,16 @@ test --@rules_rust//:rustfmt.toml=//:.rustfmt.toml
 # This will make rustfmt and clippy only run on `bazel test`.
 test --output_groups=+rustfmt_checks
 test --output_groups=+clippy_checks
+
+# Optional nightly toolchain. Mostly useful for running sanitizers.
+build:nightly --@rules_rust//rust/toolchain/channel=nightly
+
+# AddressSanitizer to detect memory leaks.
+build:asan --config=nightly -c dbg
+build:asan --@rules_rust//:extra_rustc_flags=-Zsanitizer=address
+
+# ThreadSanitizer to detect data races. Tests under tsan shouldn't be cached
+# since they tend to produce irreproducible false negatives.
+build:tsan --config=nightly -c dbg
+build:tsan --@rules_rust//:extra_rustc_flags=-Zsanitizer=thread
+test:tsan --cache_test_results=no

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -29,7 +29,10 @@ rules_rust_dependencies()
 
 rust_register_toolchains(
     edition = "2021",
-    versions = ["1.70.0"],
+    versions = [
+        "1.70.0",
+        "nightly/2023-07-15",
+    ],
 )
 
 load(

--- a/util/evicting_map.rs
+++ b/util/evicting_map.rs
@@ -219,7 +219,7 @@ where
 
     pub async fn size_for_key(&self, digest: &DigestInfo) -> Option<usize> {
         let mut state = self.state.lock().await;
-        if let Some(mut entry) = state.lru.get_mut(digest) {
+        if let Some(entry) = state.lru.get_mut(digest) {
             entry.seconds_since_anchor = self.anchor_time.elapsed().as_secs() as i32;
             let data = entry.data.clone();
             drop(state);
@@ -231,7 +231,7 @@ where
 
     pub async fn get(&self, digest: &DigestInfo) -> Option<T> {
         let mut state = self.state.lock().await;
-        if let Some(mut entry) = state.lru.get_mut(digest) {
+        if let Some(entry) = state.lru.get_mut(digest) {
             entry.seconds_since_anchor = self.anchor_time.elapsed().as_secs() as i32;
             let data = entry.data.clone();
             drop(state);

--- a/util/tests/async_fixed_buffer_test.rs
+++ b/util/tests/async_fixed_buffer_test.rs
@@ -143,7 +143,7 @@ mod async_fixed_buffer_tests {
 
         tx.write_all(&[255u8; 4]).await?;
 
-        let mut read_buffer = vec![0u8; 5];
+        let mut read_buffer = [0u8; 5];
         let read_fut = rx.read_exact(&mut read_buffer[..]);
         pin_mut!(read_fut);
 
@@ -180,7 +180,7 @@ mod async_fixed_buffer_tests {
         let raw_fixed_buffer = AsyncFixedBuf::new(vec![0u8; 32].into_boxed_slice());
         let (mut rx, mut tx) = tokio::io::split(raw_fixed_buffer);
 
-        let write_buffer = vec![0u8; 2];
+        let write_buffer = [0u8; 2];
         tx.write_all(&write_buffer[..])
             .await
             .err_tip(|| "Failed to write_all")?;
@@ -202,7 +202,7 @@ mod async_fixed_buffer_tests {
         let (mut rx, mut tx) = tokio::io::split(raw_fixed_buffer);
 
         let write_fut = async move {
-            let write_buffer = vec![0u8; 2];
+            let write_buffer = [0u8; 2];
             tx.write_all(&write_buffer[..])
                 .await
                 .err_tip(|| "Failed to write_all")?;
@@ -210,7 +210,7 @@ mod async_fixed_buffer_tests {
         };
         pin_mut!(write_fut);
 
-        let mut read_buffer = vec![0u8; 1];
+        let mut read_buffer = [0u8; 1];
 
         assert!(poll!(&mut write_fut).is_pending(), "Expecting to be pending");
         assert_eq!(


### PR DESCRIPTION
Detecting data races and memory issues in unsafe code can be difficult and time consuming.

To aid with this, add an optional nightly toolchain which exposes experimental `-Zsanitizer` flags. This lets us run builds and test with `--config=asan` and `--config=tsan` to enable AddressSanitizer and ThreadSanitizer. These sanitizers incur heavy performance penalties and shouldn't be enabled in production builds.

We can't enable these in CI yet, since ref_store_test fails under asan and all runtime tests fail under tsan.

The changed rust files fix issues that trigger nightly clippy.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/allada/turbo-cache/185)
<!-- Reviewable:end -->
