### PR TITLE
Removes name from action state

### DIFF
--- a/cas/grpc_service/execution_server.rs
+++ b/cas/grpc_service/execution_server.rs
@@ -106,7 +106,6 @@ impl InstanceInfo {
         }
 
         Ok(ActionInfo {
-            instance_name,
             command_digest,
             input_root_digest,
             timeout,
@@ -115,6 +114,7 @@ impl InstanceInfo {
             load_timestamp: UNIX_EPOCH,
             insert_timestamp: SystemTime::now(),
             unique_qualifier: ActionInfoHashKey {
+                instance_name,
                 digest: action_digest,
                 salt: if action.do_not_cache {
                     thread_rng().gen::<u64>()
@@ -188,12 +188,9 @@ impl ExecutionServer {
             .build_action_info(instance_name, digest, &action, priority, execute_req.skip_cache_lookup)
             .await?;
 
-        // Warning: This name is ignored by GrpcScheduler, so don't use it for
-        //          operations mapping here...
-        let name = format!("{:X}", thread_rng().gen::<u128>());
         let rx = instance_info
             .scheduler
-            .add_action(name, action_info)
+            .add_action(action_info)
             .await
             .err_tip(|| "Failed to schedule task")?;
 

--- a/cas/grpc_service/tests/worker_api_server_test.rs
+++ b/cas/grpc_service/tests/worker_api_server_test.rs
@@ -251,9 +251,9 @@ pub mod execution_response_tests {
 
         const SALT: u64 = 5;
         let action_digest = DigestInfo::new([7u8; 32], 123);
+        let instance_name = "instance_name".to_string();
 
         let action_info = ActionInfo {
-            instance_name: "instance_name".to_string(),
             command_digest: DigestInfo::new([0u8; 32], 0),
             input_root_digest: DigestInfo::new([0u8; 32], 0),
             timeout: Duration::MAX,
@@ -264,15 +264,13 @@ pub mod execution_response_tests {
             load_timestamp: make_system_time(0),
             insert_timestamp: make_system_time(0),
             unique_qualifier: ActionInfoHashKey {
+                instance_name: instance_name.clone(),
                 digest: action_digest,
                 salt: SALT,
             },
             skip_cache_lookup: true,
         };
-        let mut client_action_state_receiver = test_context
-            .scheduler
-            .add_action("name".to_string(), action_info)
-            .await?;
+        let mut client_action_state_receiver = test_context.scheduler.add_action(action_info).await?;
 
         let mut server_logs = HashMap::new();
         server_logs.insert(
@@ -283,6 +281,7 @@ pub mod execution_response_tests {
             },
         );
         let result = ExecuteResult {
+            instance_name,
             worker_id: test_context.worker_id.to_string(),
             action_digest: Some(action_digest.into()),
             salt: SALT,

--- a/cas/grpc_service/worker_api_server.rs
+++ b/cas/grpc_service/worker_api_server.rs
@@ -181,6 +181,7 @@ impl WorkerApiServer {
             .err_tip(|| "Expected action_digest to exist")?
             .try_into()?;
         let action_info_hash_key = ActionInfoHashKey {
+            instance_name: execute_result.instance_name,
             digest: action_digest,
             salt: execute_result.salt,
         };

--- a/cas/scheduler/cache_lookup_scheduler.rs
+++ b/cas/scheduler/cache_lookup_scheduler.rs
@@ -132,29 +132,23 @@ impl ActionScheduler for CacheLookupScheduler {
         self.action_scheduler.get_platform_property_manager(instance_name).await
     }
 
-    async fn add_action(
-        &self,
-        name: String,
-        action_info: ActionInfo,
-    ) -> Result<watch::Receiver<Arc<ActionState>>, Error> {
+    async fn add_action(&self, action_info: ActionInfo) -> Result<watch::Receiver<Arc<ActionState>>, Error> {
         if action_info.skip_cache_lookup {
             // Cache lookup skipped, forward to the upstream.
-            return self.action_scheduler.add_action(name, action_info).await;
+            return self.action_scheduler.add_action(action_info).await;
         }
-        let action_digest = action_info.digest();
         let mut current_state = Arc::new(ActionState {
-            name: name.clone(),
+            unique_qualifier: action_info.unique_qualifier.clone(),
             stage: ActionStage::CacheCheck,
-            action_digest: *action_digest,
         });
         let (tx, rx) = watch::channel(current_state.clone());
         let ac_store = self.ac_store.clone();
         let cas_store = self.cas_store.clone();
         let action_scheduler = self.action_scheduler.clone();
         tokio::spawn(async move {
-            let instance_name = action_info.instance_name.to_string();
+            let instance_name = action_info.instance_name().clone();
             if let Some(proto_action_result) =
-                get_action_from_store(ac_store, &current_state.action_digest, instance_name.clone()).await
+                get_action_from_store(ac_store, current_state.action_digest(), instance_name.clone()).await
             {
                 if validate_outputs_exist(cas_store, &proto_action_result, instance_name).await {
                     // Found in the cache, return the result immediately.
@@ -164,7 +158,7 @@ impl ActionScheduler for CacheLookupScheduler {
                 }
             }
             // Not in cache, forward to upstream and proxy state.
-            let mut watch_stream = match action_scheduler.add_action(name, action_info).await {
+            let mut watch_stream = match action_scheduler.add_action(action_info).await {
                 Ok(rx) => WatchStream::new(rx),
                 Err(err) => {
                     Arc::make_mut(&mut current_state).stage = ActionStage::Error((err, ActionResult::default()));

--- a/cas/scheduler/grpc_scheduler.rs
+++ b/cas/scheduler/grpc_scheduler.rs
@@ -81,11 +81,7 @@ impl ActionScheduler for GrpcScheduler {
         Ok(platform_property_manager)
     }
 
-    async fn add_action(
-        &self,
-        _name: String,
-        action_info: ActionInfo,
-    ) -> Result<watch::Receiver<Arc<ActionState>>, Error> {
+    async fn add_action(&self, action_info: ActionInfo) -> Result<watch::Receiver<Arc<ActionState>>, Error> {
         let execution_policy = if action_info.priority == DEFAULT_EXECUTION_PRIORITY {
             None
         } else {
@@ -94,7 +90,7 @@ impl ActionScheduler for GrpcScheduler {
             })
         };
         let request = ExecuteRequest {
-            instance_name: action_info.instance_name.clone(),
+            instance_name: action_info.instance_name().clone(),
             skip_cache_lookup: action_info.skip_cache_lookup,
             action_digest: Some(action_info.digest().into()),
             execution_policy,

--- a/cas/scheduler/scheduler.rs
+++ b/cas/scheduler/scheduler.rs
@@ -30,11 +30,7 @@ pub trait ActionScheduler: Sync + Send + Unpin {
     async fn get_platform_property_manager(&self, instance_name: &str) -> Result<Arc<PlatformPropertyManager>, Error>;
 
     /// Adds an action to the scheduler for remote execution.
-    async fn add_action(
-        &self,
-        name: String,
-        action_info: ActionInfo,
-    ) -> Result<watch::Receiver<Arc<ActionState>>, Error>;
+    async fn add_action(&self, action_info: ActionInfo) -> Result<watch::Receiver<Arc<ActionState>>, Error>;
 }
 
 /// WorkerScheduler interface is responsible for interactions between the scheduler

--- a/cas/scheduler/simple_scheduler.rs
+++ b/cas/scheduler/simple_scheduler.rs
@@ -174,11 +174,7 @@ impl SimpleSchedulerImpl {
     /// If the task cannot be executed immediately it will be queued for execution
     /// based on priority and other metrics.
     /// All further updates to the action will be provided through `listener`.
-    fn add_action(
-        &mut self,
-        name: String,
-        action_info: ActionInfo,
-    ) -> Result<watch::Receiver<Arc<ActionState>>, Error> {
+    fn add_action(&mut self, action_info: ActionInfo) -> Result<watch::Receiver<Arc<ActionState>>, Error> {
         // Check to see if the action is running, if it is and cacheable, merge the actions.
         if let Some(running_action) = self.active_actions.get_mut(&action_info) {
             let rx = running_action.action.notify_channel.subscribe();
@@ -219,16 +215,10 @@ impl SimpleSchedulerImpl {
 
         // Action needs to be added to queue or is not cacheable.
         let action_info = Arc::new(action_info);
-        let action_digest = *action_info.digest();
 
-        // TODO(allada) This name field needs to be indexable. The client might perform operations
-        // based on the name later. It cannot be the same index used as the workers though, because
-        // we multiplex the same job requests from clients to the same worker, but one client should
-        // not shutdown a job if another client is still waiting on it.
         let current_state = Arc::new(ActionState {
-            name,
+            unique_qualifier: action_info.unique_qualifier.clone(),
             stage: ActionStage::Queued,
-            action_digest,
         });
 
         let (tx, rx) = watch::channel(current_state.clone());
@@ -590,13 +580,9 @@ impl ActionScheduler for SimpleScheduler {
         Ok(self.platform_property_manager.clone())
     }
 
-    async fn add_action(
-        &self,
-        name: String,
-        action_info: ActionInfo,
-    ) -> Result<watch::Receiver<Arc<ActionState>>, Error> {
+    async fn add_action(&self, action_info: ActionInfo) -> Result<watch::Receiver<Arc<ActionState>>, Error> {
         let mut inner = self.inner.lock();
-        inner.add_action(name, action_info)
+        inner.add_action(action_info)
     }
 }
 

--- a/cas/scheduler/tests/action_messages_test.rs
+++ b/cas/scheduler/tests/action_messages_test.rs
@@ -40,8 +40,11 @@ mod action_messages_tests {
     #[tokio::test]
     async fn action_state_any_url_test() -> Result<(), Error> {
         let operation: Operation = ActionState {
-            name: "test".to_string(),
-            action_digest: DigestInfo::new([1u8; 32], 5),
+            unique_qualifier: ActionInfoHashKey {
+                instance_name: "foo_instance".to_string(),
+                digest: DigestInfo::new([1u8; 32], 5),
+                salt: 0,
+            },
             stage: ActionStage::Unknown,
         }
         .into();
@@ -94,7 +97,6 @@ mod action_messages_tests {
         const INSTANCE_NAME: &str = "foobar_instance_name";
 
         let high_priority_action = Arc::new(ActionInfo {
-            instance_name: INSTANCE_NAME.to_string(),
             command_digest: DigestInfo::new([0u8; 32], 0),
             input_root_digest: DigestInfo::new([0u8; 32], 0),
             timeout: Duration::MAX,
@@ -105,13 +107,13 @@ mod action_messages_tests {
             load_timestamp: SystemTime::UNIX_EPOCH,
             insert_timestamp: SystemTime::UNIX_EPOCH,
             unique_qualifier: ActionInfoHashKey {
+                instance_name: INSTANCE_NAME.to_string(),
                 digest: DigestInfo::new([0u8; 32], 0),
                 salt: 0,
             },
             skip_cache_lookup: true,
         });
         let lowest_priority_action = Arc::new(ActionInfo {
-            instance_name: INSTANCE_NAME.to_string(),
             command_digest: DigestInfo::new([0u8; 32], 0),
             input_root_digest: DigestInfo::new([0u8; 32], 0),
             timeout: Duration::MAX,
@@ -122,6 +124,7 @@ mod action_messages_tests {
             load_timestamp: SystemTime::UNIX_EPOCH,
             insert_timestamp: SystemTime::UNIX_EPOCH,
             unique_qualifier: ActionInfoHashKey {
+                instance_name: INSTANCE_NAME.to_string(),
                 digest: DigestInfo::new([1u8; 32], 0),
                 salt: 0,
             },
@@ -144,7 +147,6 @@ mod action_messages_tests {
         const INSTANCE_NAME: &str = "foobar_instance_name";
 
         let first_action = Arc::new(ActionInfo {
-            instance_name: INSTANCE_NAME.to_string(),
             command_digest: DigestInfo::new([0u8; 32], 0),
             input_root_digest: DigestInfo::new([0u8; 32], 0),
             timeout: Duration::MAX,
@@ -155,13 +157,13 @@ mod action_messages_tests {
             load_timestamp: SystemTime::UNIX_EPOCH,
             insert_timestamp: SystemTime::UNIX_EPOCH,
             unique_qualifier: ActionInfoHashKey {
+                instance_name: INSTANCE_NAME.to_string(),
                 digest: DigestInfo::new([0u8; 32], 0),
                 salt: 0,
             },
             skip_cache_lookup: true,
         });
         let current_action = Arc::new(ActionInfo {
-            instance_name: INSTANCE_NAME.to_string(),
             command_digest: DigestInfo::new([0u8; 32], 0),
             input_root_digest: DigestInfo::new([0u8; 32], 0),
             timeout: Duration::MAX,
@@ -172,6 +174,7 @@ mod action_messages_tests {
             load_timestamp: SystemTime::UNIX_EPOCH,
             insert_timestamp: make_system_time(0),
             unique_qualifier: ActionInfoHashKey {
+                instance_name: INSTANCE_NAME.to_string(),
                 digest: DigestInfo::new([1u8; 32], 0),
                 salt: 0,
             },

--- a/cas/scheduler/tests/utils/scheduler_utils.rs
+++ b/cas/scheduler/tests/utils/scheduler_utils.rs
@@ -23,7 +23,6 @@ pub const INSTANCE_NAME: &str = "foobar_instance_name";
 
 pub fn make_base_action_info(insert_timestamp: SystemTime) -> ActionInfo {
     ActionInfo {
-        instance_name: INSTANCE_NAME.to_string(),
         command_digest: DigestInfo::new([0u8; 32], 0),
         input_root_digest: DigestInfo::new([0u8; 32], 0),
         timeout: Duration::MAX,
@@ -34,6 +33,7 @@ pub fn make_base_action_info(insert_timestamp: SystemTime) -> ActionInfo {
         load_timestamp: UNIX_EPOCH,
         insert_timestamp,
         unique_qualifier: ActionInfoHashKey {
+            instance_name: INSTANCE_NAME.to_string(),
             digest: DigestInfo::new([0u8; 32], 0),
             salt: 0,
         },

--- a/cas/worker/tests/local_worker_test.rs
+++ b/cas/worker/tests/local_worker_test.rs
@@ -42,6 +42,8 @@ use proto::com::github::allada::turbo_cache::remote_execution::{
     UpdateForWorker,
 };
 
+const INSTANCE_NAME: &str = "foo";
+
 /// Get temporary path from either `TEST_TMPDIR` or best effort temp directory if
 /// not set.
 fn make_temp_path(data: &str) -> String {
@@ -198,7 +200,6 @@ mod local_worker_tests {
 
         let action_digest = DigestInfo::new([3u8; 32], 10);
         let action_info = ActionInfo {
-            instance_name: "foo".to_string(),
             command_digest: DigestInfo::new([1u8; 32], 10),
             input_root_digest: DigestInfo::new([2u8; 32], 10),
             timeout: Duration::from_secs(1),
@@ -207,6 +208,7 @@ mod local_worker_tests {
             load_timestamp: SystemTime::UNIX_EPOCH,
             insert_timestamp: SystemTime::UNIX_EPOCH,
             unique_qualifier: ActionInfoHashKey {
+                instance_name: INSTANCE_NAME.to_string(),
                 digest: action_digest,
                 salt: SALT,
             },
@@ -278,6 +280,7 @@ mod local_worker_tests {
             execution_response,
             ExecuteResult {
                 worker_id: expected_worker_id,
+                instance_name: INSTANCE_NAME.to_string(),
                 action_digest: Some(action_digest.into()),
                 salt: SALT,
                 result: Some(execute_result::Result::ExecuteResponse(
@@ -412,7 +415,6 @@ mod local_worker_tests {
         const SALT: u64 = 1000;
         let action_digest = DigestInfo::new([3u8; 32], 10);
         let action_info = ActionInfo {
-            instance_name: "foo".to_string(),
             command_digest: DigestInfo::new([1u8; 32], 10),
             input_root_digest: DigestInfo::new([2u8; 32], 10),
             timeout: Duration::from_secs(1),
@@ -421,6 +423,7 @@ mod local_worker_tests {
             load_timestamp: SystemTime::UNIX_EPOCH,
             insert_timestamp: SystemTime::UNIX_EPOCH,
             unique_qualifier: ActionInfoHashKey {
+                instance_name: INSTANCE_NAME.to_string(),
                 digest: action_digest,
                 salt: SALT,
             },
@@ -452,6 +455,7 @@ mod local_worker_tests {
             execution_response,
             ExecuteResult {
                 worker_id: expected_worker_id,
+                instance_name: INSTANCE_NAME.to_string(),
                 action_digest: Some(action_digest.into()),
                 salt: SALT,
                 result: Some(execute_result::Result::InternalError(

--- a/proto/com/github/allada/turbo_cache/remote_execution/worker_api.proto
+++ b/proto/com/github/allada/turbo_cache/remote_execution/worker_api.proto
@@ -95,6 +95,10 @@ message ExecuteResult {
     /// ID of the worker making the request.
     string worker_id = 1;
 
+    /// The `instance_name` this task was initially assigned to. This is set by the client
+    /// that initially sent the job as part of the BRE protocol.
+    string instance_name = 6;
+
     /// The original execution digest request for this response. The scheduler knows what it
     /// should be, but we do safety checks to ensure it really is the request we expected.
     build.bazel.remote.execution.v2.Digest action_digest = 2;
@@ -117,7 +121,7 @@ message ExecuteResult {
         google.rpc.Status internal_error = 5;
     }
 
-    reserved 6; // NextId.
+    reserved 7; // NextId.
 }
 
 /// Result sent back from the server when a node connects.

--- a/proto/genproto/com.github.allada.turbo_cache.remote_execution.pb.rs
+++ b/proto/genproto/com.github.allada.turbo_cache.remote_execution.pb.rs
@@ -55,6 +55,10 @@ pub struct ExecuteResult {
     /// / ID of the worker making the request.
     #[prost(string, tag = "1")]
     pub worker_id: ::prost::alloc::string::String,
+    /// / The `instance_name` this task was initially assigned to. This is set by the client
+    /// / that initially sent the job as part of the BRE protocol.
+    #[prost(string, tag = "6")]
+    pub instance_name: ::prost::alloc::string::String,
     /// / The original execution digest request for this response. The scheduler knows what it
     /// / should be, but we do safety checks to ensure it really is the request we expected.
     #[prost(message, optional, tag = "2")]

--- a/util/common.rs
+++ b/util/common.rs
@@ -67,7 +67,7 @@ impl DigestInfo {
         hex::encode(self.packed_hash)
     }
 
-    pub fn empty_digest() -> DigestInfo {
+    pub const fn empty_digest() -> DigestInfo {
         DigestInfo {
             size_bytes: 0,
             // Magic hash of a sha256 of empty string.


### PR DESCRIPTION
We already have a unique way to reference a task `ActionInfoHashKey`. This PR removes the need for name in the ActionState and adds `unique_qualifier` to this field instead. This PR also adds the utilities needed to convert to-from a string, so components can reference the task by a unique name.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/allada/turbo-cache/186)
<!-- Reviewable:end -->
