### PR TITLE
Add TSAN suppression and harness

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -47,4 +47,5 @@ build:asan --@rules_rust//:extra_rustc_flags=-Zsanitizer=address
 # since they tend to produce irreproducible false negatives.
 build:tsan --config=nightly -c dbg
 build:tsan --@rules_rust//:extra_rustc_flags=-Zsanitizer=thread
-test:tsan --cache_test_results=no
+build:tsan --cache_test_results=no
+build:tsan --run_under=//tools:tsan.sh

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -1,0 +1,15 @@
+# Copyright 2022 The Turbo Cache Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+exports_files(["tsan.sh"])

--- a/tools/tsan.sh
+++ b/tools/tsan.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Copyright 2022 The Turbo Cache Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file is used to run tests under ThreadSanitizer. Generally it should
+# be invoked under bazel using `bazel run --config tsan //{target_here}`.
+set -euo pipefail
+
+export TMPDIR="${TEST_TMPDIR:-${TMPDIR:-/tmp}}"
+tsan_suppresions_file=$(mktemp -t tsan_suppressions.XXXXXX)
+trap "rm -f $tsan_suppresions_file" EXIT
+
+cat <<EOF > "$tsan_suppresions_file"
+race:std::rt::lang_start_internal
+EOF
+
+export TSAN_OPTIONS="suppressions=$tsan_suppresions_file"
+export RUST_TEST_THREADS=1
+# Note: We cannot use `exec` here or else our `trap` cleanup will not run.
+"$@"


### PR DESCRIPTION
Bazel does not make it easy to add a file to every test as a dependency. But it does have --run_under, so we hijack this in order to make our suppression file. Later we may want to make a macro override for our test rules to add the suppression file if it grows too large.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/allada/turbo-cache/189)
<!-- Reviewable:end -->
