### PR TITLE
Fix false positives for `--config=tsan`.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -43,8 +43,13 @@ build:nightly --@rules_rust//rust/toolchain/channel=nightly
 build:asan --config=nightly -c dbg
 build:asan --@rules_rust//:extra_rustc_flags=-Zsanitizer=address
 
-# ThreadSanitizer to detect data races. Tests under tsan shouldn't be cached
-# since they tend to produce irreproducible false negatives.
+# ThreadSanitizer to detect data races.
+#
+# Tests under tsan shouldn't be cached since they tend to produce irreproducible
+# false negatives. Tests in each file need to run in serial and a checks on a
+# few symbols need to be explicitly suppressed.
 build:tsan --config=nightly -c dbg
 build:tsan --@rules_rust//:extra_rustc_flags=-Zsanitizer=thread
 test:tsan --cache_test_results=no
+test:tsan --test_env=RUST_TEST_THREADS=1
+test:tsan --test_env=TSAN_OPTIONS="suppressions=.tsanignore"

--- a/.tsanignore
+++ b/.tsanignore
@@ -1,0 +1,2 @@
+# Rust doesn't support this.
+race:std::rt::lang_start_internal

--- a/BUILD
+++ b/BUILD
@@ -1,4 +1,7 @@
-exports_files([".rustfmt.toml"])
+exports_files([
+    ".rustfmt.toml",
+    ".tsanignore",
+])
 
 genrule(
     name = "dummy_test_sh",

--- a/cas/grpc_service/BUILD
+++ b/cas/grpc_service/BUILD
@@ -118,6 +118,7 @@ rust_library(
 rust_test(
     name = "worker_api_server_test",
     srcs = ["tests/worker_api_server_test.rs"],
+    data = ["//:.tsanignore"],
     deps = [
         ":worker_api_server",
         "//cas/scheduler",
@@ -139,6 +140,7 @@ rust_test(
 rust_test(
     name = "cas_server_test",
     srcs = ["tests/cas_server_test.rs"],
+    data = ["//:.tsanignore"],
     deps = [
         ":cas_server",
         "//cas/store",
@@ -157,6 +159,7 @@ rust_test(
 rust_test(
     name = "ac_server_test",
     srcs = ["tests/ac_server_test.rs"],
+    data = ["//:.tsanignore"],
     deps = [
         ":ac_server",
         "//cas/store",
@@ -177,6 +180,7 @@ rust_test(
 rust_test(
     name = "bytestream_server_test",
     srcs = ["tests/bytestream_server_test.rs"],
+    data = ["//:.tsanignore"],
     deps = [
         ":bytestream_server",
         "//cas/store",

--- a/cas/scheduler/BUILD
+++ b/cas/scheduler/BUILD
@@ -17,11 +17,11 @@ rust_library(
 rust_library(
     name = "scheduler",
     srcs = ["scheduler.rs"],
+    proc_macro_deps = ["@crate_index//:async-trait"],
     visibility = [
         "//cas:__pkg__",
         "//cas:__subpackages__",
     ],
-    proc_macro_deps = ["@crate_index//:async-trait"],
     deps = [
         ":action_messages",
         ":platform_property_manager",
@@ -35,11 +35,11 @@ rust_library(
     name = "mock_scheduler",
     testonly = True,
     srcs = ["tests/utils/mock_scheduler.rs"],
+    proc_macro_deps = ["@crate_index//:async-trait"],
     visibility = [
         "//cas:__pkg__",
         "//cas:__subpackages__",
     ],
-    proc_macro_deps = ["@crate_index//:async-trait"],
     deps = [
         ":action_messages",
         ":platform_property_manager",
@@ -53,11 +53,11 @@ rust_library(
     name = "scheduler_utils",
     testonly = True,
     srcs = ["tests/utils/scheduler_utils.rs"],
+    proc_macro_deps = ["@crate_index//:async-trait"],
     visibility = [
         "//cas:__pkg__",
         "//cas:__subpackages__",
     ],
-    proc_macro_deps = ["@crate_index//:async-trait"],
     deps = [
         ":action_messages",
         ":platform_property_manager",
@@ -68,11 +68,11 @@ rust_library(
 rust_library(
     name = "simple_scheduler",
     srcs = ["simple_scheduler.rs"],
+    proc_macro_deps = ["@crate_index//:async-trait"],
     visibility = [
         "//cas:__pkg__",
         "//cas:__subpackages__",
     ],
-    proc_macro_deps = ["@crate_index//:async-trait"],
     deps = [
         ":action_messages",
         ":platform_property_manager",
@@ -81,9 +81,9 @@ rust_library(
         "//config",
         "//util:common",
         "//util:error",
-        "@crate_index//:parking_lot",
         "@crate_index//:futures",
         "@crate_index//:lru",
+        "@crate_index//:parking_lot",
         "@crate_index//:tokio",
     ],
 )
@@ -91,11 +91,11 @@ rust_library(
 rust_library(
     name = "cache_lookup_scheduler",
     srcs = ["cache_lookup_scheduler.rs"],
+    proc_macro_deps = ["@crate_index//:async-trait"],
     visibility = [
         "//cas:__pkg__",
         "//cas:__subpackages__",
     ],
-    proc_macro_deps = ["@crate_index//:async-trait"],
     deps = [
         ":action_messages",
         ":platform_property_manager",
@@ -109,15 +109,16 @@ rust_library(
         "//util:common",
         "//util:error",
         "@crate_index//:futures",
-        "@crate_index//:tonic",
         "@crate_index//:tokio",
         "@crate_index//:tokio-stream",
+        "@crate_index//:tonic",
     ],
 )
 
 rust_test(
     name = "cache_lookup_scheduler_test",
     srcs = ["tests/cache_lookup_scheduler_test.rs"],
+    data = ["//:.tsanignore"],
     deps = [
         ":action_messages",
         ":cache_lookup_scheduler",
@@ -141,11 +142,11 @@ rust_test(
 rust_library(
     name = "grpc_scheduler",
     srcs = ["grpc_scheduler.rs"],
+    proc_macro_deps = ["@crate_index//:async-trait"],
     visibility = [
         "//cas:__pkg__",
         "//cas:__subpackages__",
     ],
-    proc_macro_deps = ["@crate_index//:async-trait"],
     deps = [
         ":action_messages",
         ":platform_property_manager",
@@ -218,6 +219,7 @@ rust_library(
 rust_test(
     name = "action_messages_test",
     srcs = ["tests/action_messages_test.rs"],
+    data = ["//:.tsanignore"],
     deps = [
         ":action_messages",
         ":platform_property_manager",
@@ -232,6 +234,7 @@ rust_test(
 rust_test(
     name = "simple_scheduler_test",
     srcs = ["tests/simple_scheduler_test.rs"],
+    data = ["//:.tsanignore"],
     visibility = [
         "//cas:__pkg__",
         "//cas:__subpackages__",

--- a/cas/store/BUILD
+++ b/cas/store/BUILD
@@ -276,6 +276,7 @@ rust_library(
 rust_test(
     name = "size_partitioning_store_test",
     srcs = ["tests/size_partitioning_store_test.rs"],
+    data = ["//:.tsanignore"],
     deps = [
         ":memory_store",
         ":size_partitioning_store",
@@ -291,6 +292,7 @@ rust_test(
 rust_test(
     name = "ref_store_test",
     srcs = ["tests/ref_store_test.rs"],
+    data = ["//:.tsanignore"],
     deps = [
         ":memory_store",
         ":ref_store",
@@ -306,6 +308,7 @@ rust_test(
 rust_test(
     name = "fast_slow_store_test",
     srcs = ["tests/fast_slow_store_test.rs"],
+    data = ["//:.tsanignore"],
     deps = [
         ":fast_slow_store",
         ":memory_store",
@@ -322,6 +325,7 @@ rust_test(
 rust_test(
     name = "memory_store_test",
     srcs = ["tests/memory_store_test.rs"],
+    data = ["//:.tsanignore"],
     deps = [
         ":memory_store",
         ":traits",
@@ -336,6 +340,7 @@ rust_test(
 rust_test(
     name = "verify_store_test",
     srcs = ["tests/verify_store_test.rs"],
+    data = ["//:.tsanignore"],
     deps = [
         ":memory_store",
         ":traits",
@@ -353,6 +358,7 @@ rust_test(
 rust_test(
     name = "s3_store_test",
     srcs = ["tests/s3_store_test.rs"],
+    data = ["//:.tsanignore"],
     deps = [
         ":s3_store",
         ":traits",
@@ -374,6 +380,7 @@ rust_test(
 rust_test(
     name = "compression_store_test",
     srcs = ["tests/compression_store_test.rs"],
+    data = ["//:.tsanignore"],
     deps = [
         ":compression_store",
         ":memory_store",
@@ -393,6 +400,7 @@ rust_test(
 rust_test(
     name = "dedup_store_test",
     srcs = ["tests/dedup_store_test.rs"],
+    data = ["//:.tsanignore"],
     deps = [
         ":dedup_store",
         ":memory_store",
@@ -409,6 +417,8 @@ rust_test(
 rust_test(
     name = "filesystem_store_test",
     srcs = ["tests/filesystem_store_test.rs"],
+    data = ["//:.tsanignore"],
+    proc_macro_deps = ["@crate_index//:async-trait"],
     deps = [
         ":filesystem_store",
         ":traits",
@@ -426,5 +436,4 @@ rust_test(
         "@crate_index//:tokio",
         "@crate_index//:tokio-stream",
     ],
-    proc_macro_deps = ["@crate_index//:async-trait"],
 )

--- a/cas/worker/BUILD
+++ b/cas/worker/BUILD
@@ -27,13 +27,13 @@ rust_library(
     srcs = ["running_actions_manager.rs"],
     proc_macro_deps = ["@crate_index//:async-trait"],
     deps = [
-        "//config",
         "//cas/scheduler:action_messages",
         "//cas/store",
         "//cas/store:ac_utils",
         "//cas/store:fast_slow_store",
         "//cas/store:filesystem_store",
         "//cas/store:grpc_store",
+        "//config",
         "//proto",
         "//util:common",
         "//util:error",
@@ -127,7 +127,10 @@ rust_library(
 rust_test(
     name = "running_actions_manager_test",
     srcs = ["tests/running_actions_manager_test.rs"],
-    data = ["tests/wrapper_for_test.sh"],
+    data = [
+        "tests/wrapper_for_test.sh",
+        "//:.tsanignore",
+    ],
     deps = [
         ":running_actions_manager",
         "//cas/scheduler:action_messages",
@@ -151,6 +154,7 @@ rust_test(
 rust_test(
     name = "local_worker_test",
     srcs = ["tests/local_worker_test.rs"],
+    data = ["//:.tsanignore"],
     proc_macro_deps = ["@crate_index//:ctor"],
     deps = [
         ":local_worker",

--- a/util/BUILD
+++ b/util/BUILD
@@ -145,6 +145,7 @@ rust_library(
 rust_test(
     name = "resource_info_test",
     srcs = ["tests/resource_info_test.rs"],
+    data = ["//:.tsanignore"],
     deps = [
         ":resource_info",
         "@crate_index//:pretty_assertions",
@@ -155,7 +156,10 @@ rust_test(
 rust_test(
     name = "fastcdc_test",
     srcs = ["tests/fastcdc_test.rs"],
-    data = ["tests/data/SekienAkashita.jpg"],
+    data = [
+        "tests/data/SekienAkashita.jpg",
+        "//:.tsanignore",
+    ],
     deps = [
         ":fastcdc",
         "//util:common",
@@ -173,6 +177,7 @@ rust_test(
 rust_test(
     name = "async_fixed_buffer_test",
     srcs = ["tests/async_fixed_buffer_test.rs"],
+    data = ["//:.tsanignore"],
     deps = [
         ":async_fixed_buffer",
         ":error",
@@ -185,6 +190,7 @@ rust_test(
 rust_test(
     name = "evicting_map_test",
     srcs = ["tests/evicting_map_test.rs"],
+    data = ["//:.tsanignore"],
     proc_macro_deps = ["@crate_index//:async-trait"],
     deps = [
         ":error",
@@ -201,6 +207,7 @@ rust_test(
 rust_test(
     name = "retry_test",
     srcs = ["tests/retry_test.rs"],
+    data = ["//:.tsanignore"],
     deps = [
         ":error",
         ":retry",
@@ -213,6 +220,7 @@ rust_test(
 rust_test(
     name = "buf_channel_test",
     srcs = ["tests/buf_channel_test.rs"],
+    data = ["//:.tsanignore"],
     deps = [
         ":buf_channel",
         ":error",


### PR DESCRIPTION
Run tests under tsan in serial, and introduce a `.tsanignore` to selectively disable warnings on unfixable symbols.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/allada/turbo-cache/190)
<!-- Reviewable:end -->
