### PR TITLE
Change StoreTrait::has to take HashSet.

### DIFF
--- a/cas/grpc_service/cas_server.rs
+++ b/cas/grpc_service/cas_server.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use bytes::Bytes;
-use futures::{stream::FuturesUnordered, stream::Stream, StreamExt, TryStreamExt};
+use futures::{stream::FuturesUnordered, stream::Stream, TryStreamExt};
 use proto::google::rpc::Status as GrpcStatus;
 use tonic::{Request, Response, Status};
 
@@ -31,7 +31,7 @@ use proto::build::bazel::remote::execution::v2::{
     batch_read_blobs_response, batch_update_blobs_response,
     content_addressable_storage_server::ContentAddressableStorage,
     content_addressable_storage_server::ContentAddressableStorageServer as Server, BatchReadBlobsRequest,
-    BatchReadBlobsResponse, BatchUpdateBlobsRequest, BatchUpdateBlobsResponse, Digest, FindMissingBlobsRequest,
+    BatchReadBlobsResponse, BatchUpdateBlobsRequest, BatchUpdateBlobsResponse, FindMissingBlobsRequest,
     FindMissingBlobsResponse, GetTreeRequest, GetTreeResponse,
 };
 use store::{Store, StoreManager};
@@ -71,39 +71,19 @@ impl CasServer {
             .err_tip(|| format!("'instance_name' not configured for '{}'", instance_name))?
             .clone();
 
-        // If we are a GrpcStore we shortcut here, as this is a special store.
-        let any_store = store.clone().as_any();
-        let maybe_grpc_store = any_store.downcast_ref::<Arc<GrpcStore>>();
-        if let Some(grpc_store) = maybe_grpc_store {
-            return grpc_store.find_missing_blobs(Request::new(inner_request)).await;
+        let mut requested_blobs = Vec::with_capacity(inner_request.blob_digests.len());
+        for digest in inner_request.blob_digests.iter() {
+            requested_blobs.push(DigestInfo::try_from(digest.clone())?);
         }
-
-        let store_pin = Pin::new(store.as_ref());
-        let check_futures: FuturesUnordered<_> = inner_request
-            .blob_digests
+        let sizes = Pin::new(store.as_ref())
+            .has_many(&requested_blobs)
+            .await
+            .err_tip(|| "In find_missing_blobs")?;
+        let missing_blob_digests = sizes
             .into_iter()
-            .map(|digest| async move {
-                let digest_info = match DigestInfo::try_from(digest.clone()) {
-                    Ok(digest_info) => digest_info,
-                    Err(err) => return Some(Err(err)),
-                };
-                match store_pin.has(digest_info).await {
-                    Ok(maybe_size) => maybe_size.map_or(Some(Ok(digest)), |_| None),
-                    Err(err) => {
-                        log::error!(
-                            "Error during .has() call in .find_missing_blobs() : {:?} - {}",
-                            err,
-                            digest_info.hash_str()
-                        );
-                        Some(Ok(digest))
-                    }
-                }
-            })
+            .zip(inner_request.blob_digests)
+            .filter_map(|(maybe_size, digest)| maybe_size.map_or_else(|| Some(digest), |_| None))
             .collect();
-        let missing_blob_digests = check_futures
-            .filter_map(|result| async move { result })
-            .try_collect::<Vec<Digest>>()
-            .await?;
 
         Ok(Response::new(FindMissingBlobsResponse { missing_blob_digests }))
     }

--- a/cas/grpc_service/tests/bytestream_server_test.rs
+++ b/cas/grpc_service/tests/bytestream_server_test.rs
@@ -140,7 +140,10 @@ pub mod write_tests {
             assert_eq!(committed_size, raw_data.len());
 
             // Now lets check our store to ensure it was written with proper data.
-            store.has(DigestInfo::try_new(HASH1, raw_data.len())?).await?;
+            assert!(
+                store.has(DigestInfo::try_new(HASH1, raw_data.len())?).await?.is_some(),
+                "Not found in store",
+            );
             let store_data = store
                 .get_part_unchunked(DigestInfo::try_new(HASH1, raw_data.len())?, 0, None, None)
                 .await?;

--- a/cas/scheduler/cache_lookup_scheduler.rs
+++ b/cas/scheduler/cache_lookup_scheduler.rs
@@ -17,7 +17,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use futures::stream::{FuturesUnordered, StreamExt};
+use futures::stream::StreamExt;
 use tokio::select;
 use tokio::sync::watch;
 use tokio_stream::wrappers::WatchStream;
@@ -30,9 +30,7 @@ use error::Error;
 use grpc_store::GrpcStore;
 use parking_lot::{Mutex, MutexGuard};
 use platform_property_manager::PlatformPropertyManager;
-use proto::build::bazel::remote::execution::v2::{
-    ActionResult as ProtoActionResult, FindMissingBlobsRequest, GetActionResultRequest,
-};
+use proto::build::bazel::remote::execution::v2::{ActionResult as ProtoActionResult, GetActionResultRequest};
 use scheduler::ActionScheduler;
 use store::Store;
 
@@ -82,13 +80,11 @@ async fn get_action_from_store(
     }
 }
 
-async fn validate_outputs_exist(
-    cas_store: Arc<dyn Store>,
-    action_result: &ProtoActionResult,
-    instance_name: String,
-) -> bool {
+async fn validate_outputs_exist(cas_store: Arc<dyn Store>, action_result: &ProtoActionResult) -> bool {
     // Verify that output_files and output_directories are available in the cas.
-    let required_digests = action_result
+    let mut required_digests =
+        Vec::with_capacity(action_result.output_files.len() + action_result.output_directories.len());
+    for digest in action_result
         .output_files
         .iter()
         .filter_map(|output_file| output_file.digest.clone())
@@ -98,28 +94,17 @@ async fn validate_outputs_exist(
                 .iter()
                 .filter_map(|output_directory| output_directory.tree_digest.clone()),
         )
-        .collect();
-
-    // If the CAS is a GrpcStore store we can check all the digests in one message.
-    let any_store = cas_store.clone().as_any();
-    let maybe_grpc_store = any_store.downcast_ref::<Arc<GrpcStore>>();
-    if let Some(grpc_store) = maybe_grpc_store {
-        grpc_store
-            .find_missing_blobs(Request::new(FindMissingBlobsRequest {
-                instance_name,
-                blob_digests: required_digests,
-            }))
-            .await
-            .is_ok_and(|find_result| find_result.into_inner().missing_blob_digests.is_empty())
-    } else {
-        let cas_pin = Pin::new(cas_store.as_ref());
-        required_digests
-            .into_iter()
-            .map(|digest| async move { cas_pin.has(DigestInfo::try_from(digest)?).await })
-            .collect::<FuturesUnordered<_>>()
-            .all(|result| async { result.is_ok_and(|result| result.is_some()) })
-            .await
+    {
+        let Ok(digest) = DigestInfo::try_from(digest) else {
+            return false;
+        };
+        required_digests.push(digest);
     }
+
+    let Ok(sizes) = Pin::new(cas_store.as_ref()).has_many(&required_digests).await else {
+        return false;
+    };
+    sizes.into_iter().all(|size| size.is_some())
 }
 
 fn subscribe_to_existing_action(
@@ -187,7 +172,7 @@ impl ActionScheduler for CacheLookupScheduler {
             if let Some(proto_action_result) =
                 get_action_from_store(ac_store, current_state.action_digest(), instance_name.clone()).await
             {
-                if validate_outputs_exist(cas_store, &proto_action_result, instance_name).await {
+                if validate_outputs_exist(cas_store, &proto_action_result).await {
                     // Found in the cache, return the result immediately.
                     Arc::make_mut(&mut current_state).stage = ActionStage::CompletedFromCache(proto_action_result);
                     let _ = tx.send(current_state);

--- a/cas/store/BUILD
+++ b/cas/store/BUILD
@@ -83,6 +83,7 @@ rust_library(
         "//util:buf_channel",
         "//util:common",
         "//util:error",
+        "@crate_index//:tokio",
     ],
 )
 

--- a/cas/store/compression_store.rs
+++ b/cas/store/compression_store.rs
@@ -233,8 +233,14 @@ impl CompressionStore {
 
 #[async_trait]
 impl StoreTrait for CompressionStore {
-    async fn has(self: Pin<&Self>, digest: DigestInfo) -> Result<Option<usize>, Error> {
-        Pin::new(self.inner_store.as_ref()).has(digest).await
+    async fn has_with_results(
+        self: Pin<&Self>,
+        digests: &[DigestInfo],
+        results: &mut [Option<usize>],
+    ) -> Result<(), Error> {
+        Pin::new(self.inner_store.as_ref())
+            .has_with_results(digests, results)
+            .await
     }
 
     async fn update(

--- a/cas/store/fast_slow_store.rs
+++ b/cas/store/fast_slow_store.rs
@@ -84,13 +84,31 @@ impl FastSlowStore {
 
 #[async_trait]
 impl StoreTrait for FastSlowStore {
-    async fn has(self: Pin<&Self>, digest: DigestInfo) -> Result<Option<usize>, Error> {
-        // TODO(blaise.bruer) Investigate if we should maybe ignore errors here instead of
-        // forwarding the up.
-        if let Some(sz) = self.pin_fast_store().has(digest).await? {
-            return Ok(Some(sz));
+    async fn has_with_results(
+        self: Pin<&Self>,
+        digests: &[DigestInfo],
+        results: &mut [Option<usize>],
+    ) -> Result<(), Error> {
+        self.pin_fast_store().has_with_results(digests, results).await?;
+        let missing_digests: Vec<DigestInfo> = results
+            .iter()
+            .zip(digests.iter())
+            .filter_map(|(result, digest)| result.map_or_else(|| Some(*digest), |_| None))
+            .collect();
+        if !missing_digests.is_empty() {
+            let mut slow_store_results = self.pin_slow_store().has_many(&missing_digests).await?.into_iter();
+            // We did not change our `result` order and the slow store's results are all the None
+            // entries in `results`. This means we can just iterate over the `results`, find the None
+            // items and put in whatever the next item in the results from `slow_store_results`.
+            for result in results.iter_mut() {
+                if result.is_none() {
+                    *result = slow_store_results
+                        .next()
+                        .err_tip(|| "slow_store_results out of sync with missing_digests")?;
+                }
+            }
         }
-        self.pin_slow_store().has(digest).await
+        Ok(())
     }
 
     async fn update(
@@ -170,16 +188,12 @@ impl StoreTrait for FastSlowStore {
         let sz_result = slow_store
             .has(digest)
             .await
-            .err_tip(|| "Failed to run has() on slow store");
-        let sz = match sz_result {
-            Ok(Some(sz)) => sz,
-            Ok(None) => {
-                return Err(make_err!(
-                    Code::NotFound,
-                    "Object not found in either fast or slow store"
-                ))
-            }
-            Err(err) => return Err(err),
+            .err_tip(|| "Failed to run has() on slow store")?;
+        let Some(sz) = sz_result else {
+            return Err(make_err!(
+                Code::NotFound,
+                "Object not found in either fast or slow store"
+            ));
         };
 
         let (mut fast_tx, fast_rx) = make_buf_channel_pair();

--- a/cas/store/filesystem_store.rs
+++ b/cas/store/filesystem_store.rs
@@ -565,8 +565,13 @@ impl<Fe: FileEntry> FilesystemStore<Fe> {
 
 #[async_trait]
 impl<Fe: FileEntry> StoreTrait for FilesystemStore<Fe> {
-    async fn has(self: Pin<&Self>, digest: DigestInfo) -> Result<Option<usize>, Error> {
-        Ok(self.evicting_map.size_for_key(&digest).await)
+    async fn has_with_results(
+        self: Pin<&Self>,
+        digests: &[DigestInfo],
+        results: &mut [Option<usize>],
+    ) -> Result<(), Error> {
+        self.evicting_map.sizes_for_keys(digests, results).await;
+        Ok(())
     }
 
     async fn update(

--- a/cas/store/grpc_store.rs
+++ b/cas/store/grpc_store.rs
@@ -17,7 +17,8 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use bytes::BytesMut;
-use futures::{stream::unfold, Stream};
+use futures::stream::{unfold, FuturesUnordered};
+use futures::{future, Stream, TryStreamExt};
 use prost::Message;
 use tonic::{transport, IntoRequest, Request, Response, Streaming};
 use uuid::Uuid;
@@ -360,30 +361,56 @@ impl GrpcStore {
 impl StoreTrait for GrpcStore {
     // NOTE: This function can only be safely used on CAS stores. AC stores may return a size that
     // is incorrect.
-    async fn has(self: Pin<&Self>, digest: DigestInfo) -> Result<Option<usize>, Error> {
+    async fn has_with_results(
+        self: Pin<&Self>,
+        digests: &[DigestInfo],
+        results: &mut [Option<usize>],
+    ) -> Result<(), Error> {
         if matches!(self.store_type, config::stores::StoreType::AC) {
-            // The length of an AC is incorrect, so we don't figure out the
-            // length, instead the biggest possible result is returned in the
-            // hope that we detect incorrect usage.
-            return self
-                .get_action_result_from_digest(digest)
+            digests
+                .iter()
+                .zip(results.iter_mut())
+                .map(|(digest, result)| async move {
+                    // The length of an AC is incorrect, so we don't figure out the
+                    // length, instead the biggest possible result is returned in the
+                    // hope that we detect incorrect usage.
+                    self.get_action_result_from_digest(*digest).await?;
+                    *result = Some(usize::MAX);
+                    Ok::<_, Error>(())
+                })
+                .collect::<FuturesUnordered<_>>()
+                .try_for_each(|_| future::ready(Ok(())))
                 .await
-                .map(|_| Some(usize::MAX));
+                .err_tip(|| "Getting upstream action cache entry")?;
+            return Ok(());
         }
 
-        let digest_size =
-            usize::try_from(digest.size_bytes).err_tip(|| "GrpcStore digest size cannot be converted to usize")?;
         let missing_blobs_response = self
             .find_missing_blobs(Request::new(FindMissingBlobsRequest {
                 instance_name: self.instance_name.clone(),
-                blob_digests: vec![digest.into()],
+                blob_digests: digests.iter().map(|digest| digest.into()).collect(),
             }))
             .await?
             .into_inner();
-        if missing_blobs_response.missing_blob_digests.is_empty() {
-            return Ok(Some(digest_size));
+
+        // Since the ordering is not guaranteed above, the matching has to check
+        // all missing blobs against all entries in the unsorted digest list.
+        // To optimise this, the missing digests are sorted and then it is
+        // efficient to perform a binary search for each digest within the
+        // missing list.
+        let mut missing_digests = Vec::with_capacity(missing_blobs_response.missing_blob_digests.len());
+        for missing_digest in missing_blobs_response.missing_blob_digests {
+            missing_digests.push(DigestInfo::try_from(missing_digest)?);
         }
-        return Ok(None);
+        missing_digests.sort_unstable();
+        for (digest, result) in digests.iter().zip(results.iter_mut()) {
+            match missing_digests.binary_search(digest) {
+                Ok(_) => *result = None,
+                Err(_) => *result = Some(usize::try_from(digest.size_bytes)?),
+            }
+        }
+
+        Ok(())
     }
 
     async fn update(

--- a/cas/store/memory_store.rs
+++ b/cas/store/memory_store.rs
@@ -67,8 +67,13 @@ impl MemoryStore {
 
 #[async_trait]
 impl StoreTrait for MemoryStore {
-    async fn has(self: Pin<&Self>, digest: DigestInfo) -> Result<Option<usize>, Error> {
-        Ok(self.map.size_for_key(&digest).await)
+    async fn has_with_results(
+        self: Pin<&Self>,
+        digests: &[DigestInfo],
+        results: &mut [Option<usize>],
+    ) -> Result<(), Error> {
+        self.map.sizes_for_keys(digests, results).await;
+        Ok(())
     }
 
     async fn update(

--- a/cas/store/ref_store.rs
+++ b/cas/store/ref_store.rs
@@ -91,9 +91,13 @@ impl RefStore {
 
 #[async_trait]
 impl StoreTrait for RefStore {
-    async fn has(self: Pin<&Self>, digest: DigestInfo) -> Result<Option<usize>, Error> {
+    async fn has_with_results(
+        self: Pin<&Self>,
+        digests: &[DigestInfo],
+        results: &mut [Option<usize>],
+    ) -> Result<(), Error> {
         let store = self.get_store()?;
-        Pin::new(store.as_ref()).has(digest).await
+        Pin::new(store.as_ref()).has_with_results(digests, results).await
     }
 
     async fn update(

--- a/cas/store/s3_store.rs
+++ b/cas/store/s3_store.rs
@@ -21,7 +21,8 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use futures::future::{try_join_all, FutureExt};
-use futures::stream::unfold;
+use futures::stream::{unfold, FuturesUnordered};
+use futures::TryStreamExt;
 use http::status::StatusCode;
 use lazy_static::lazy_static;
 use rand::{rngs::OsRng, Rng};
@@ -184,15 +185,12 @@ impl S3Store {
     fn make_s3_path(&self, digest: &DigestInfo) -> String {
         format!("{}{}-{}", self.key_prefix, digest.hash_str(), digest.size_bytes)
     }
-}
 
-#[async_trait]
-impl StoreTrait for S3Store {
-    async fn has(self: Pin<&Self>, digest: DigestInfo) -> Result<Option<usize>, Error> {
+    async fn has(self: Pin<&Self>, digest: &DigestInfo) -> Result<Option<usize>, Error> {
         let retry_config = ExponentialBackoff::new(Duration::from_millis(self.retry.delay as u64))
             .map(|d| (self.jitter_fn)(d))
             .take(self.retry.max_retries); // Remember this is number of retries, so will run max_retries + 1.
-        let s3_path = &self.make_s3_path(&digest);
+        let s3_path = &self.make_s3_path(digest);
         self.retrier
             .retry(
                 retry_config,
@@ -237,6 +235,27 @@ impl StoreTrait for S3Store {
                 }),
             )
             .await
+    }
+}
+
+#[async_trait]
+impl StoreTrait for S3Store {
+    async fn has_with_results(
+        self: Pin<&Self>,
+        digests: &[DigestInfo],
+        results: &mut [Option<usize>],
+    ) -> Result<(), Error> {
+        digests
+            .iter()
+            .zip(results.iter_mut())
+            .map(|(digest, result)| async move {
+                *result = self.has(digest).await?;
+                Ok::<_, Error>(())
+            })
+            .collect::<FuturesUnordered<_>>()
+            .try_collect()
+            .await?;
+        Ok(())
     }
 
     async fn update(

--- a/cas/store/verify_store.rs
+++ b/cas/store/verify_store.rs
@@ -97,8 +97,12 @@ async fn inner_check_update(
 
 #[async_trait]
 impl StoreTrait for VerifyStore {
-    async fn has(self: Pin<&Self>, digest: DigestInfo) -> Result<Option<usize>, Error> {
-        self.pin_inner().has(digest).await
+    async fn has_with_results(
+        self: Pin<&Self>,
+        digests: &[DigestInfo],
+        results: &mut [Option<usize>],
+    ) -> Result<(), Error> {
+        self.pin_inner().has_with_results(digests, results).await
     }
 
     async fn update(

--- a/util/BUILD
+++ b/util/BUILD
@@ -81,6 +81,7 @@ rust_library(
         "//config",
         "//util:common",
         "@crate_index//:async-lock",
+        "@crate_index//:futures",
         "@crate_index//:lru",
         "@crate_index//:serde",
     ],

--- a/util/common.rs
+++ b/util/common.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::convert::{TryFrom, TryInto};
 use std::fmt;
@@ -85,6 +86,24 @@ impl fmt::Debug for DigestInfo {
             .field("size_bytes", &self.size_bytes)
             .field("hash", &self.hash_str())
             .finish()
+    }
+}
+
+impl Ord for DigestInfo {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.packed_hash
+            .cmp(&other.packed_hash)
+            .then_with(|| self.size_bytes.cmp(&other.size_bytes))
+    }
+}
+
+impl PartialOrd for DigestInfo {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        let cmp = self.cmp(other);
+        if cmp == Ordering::Equal {
+            return None;
+        }
+        Some(cmp)
     }
 }
 

--- a/util/evicting_map.rs
+++ b/util/evicting_map.rs
@@ -19,6 +19,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use async_lock::Mutex;
 use async_trait::async_trait;
+use futures::{future, stream::FuturesUnordered, StreamExt};
 use lru::LruCache;
 use serde::{Deserialize, Serialize};
 
@@ -219,14 +220,39 @@ where
 
     pub async fn size_for_key(&self, digest: &DigestInfo) -> Option<usize> {
         let mut state = self.state.lock().await;
-        if let Some(entry) = state.lru.get_mut(digest) {
-            entry.seconds_since_anchor = self.anchor_time.elapsed().as_secs() as i32;
-            let data = entry.data.clone();
-            drop(state);
-            data.touch().await;
-            return Some(data.len());
-        }
-        None
+        let Some(entry) = state.lru.get_mut(digest) else {
+            return None;
+        };
+        entry.seconds_since_anchor = self.anchor_time.elapsed().as_secs() as i32;
+        let data = entry.data.clone();
+        drop(state);
+        data.touch().await;
+        Some(data.len())
+    }
+
+    pub async fn sizes_for_keys(&self, digests: &[DigestInfo], results: &mut [Option<usize>]) {
+        let mut state = self.state.lock().await;
+        let seconds_since_anchor = self.anchor_time.elapsed().as_secs() as i32;
+        let to_touch: Vec<T> = digests
+            .iter()
+            .zip(results.iter_mut())
+            .filter_map(|(digest, result)| {
+                let Some(entry) = state.lru.get_mut(digest) else {
+                    return None;
+                };
+                entry.seconds_since_anchor = seconds_since_anchor;
+                let data = entry.data.clone();
+                *result = Some(data.len());
+                Some(data)
+            })
+            .collect();
+        drop(state);
+        to_touch
+            .iter()
+            .map(|data| data.touch())
+            .collect::<FuturesUnordered<_>>()
+            .for_each(|_| future::ready(()))
+            .await;
     }
 
     pub async fn get(&self, digest: &DigestInfo) -> Option<T> {


### PR DESCRIPTION
Currently the `has` method in the StoreTrait takes a single DigestInfo which means that it only has to do a single lookup at a time.  This is optimised in places for the GrpcStore to ensure that efficient upstream lookups are performed.

However, if the GrpcStore is wrapped in another store (e.g. FastSlowStore for a local cache) then the `has` call is performed for each DigestInfo which is very inefficient on the GrpcStore call.

This optimises that use case by having each Store implementation pass through all DigestInfos that are being requested meaning the by-pass is no longer required for GrpcStore::has and all other stores can make use of the optimised route.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/allada/turbo-cache/198)
<!-- Reviewable:end -->
