### PR TITLE
Don't remove Error context.

### DIFF
--- a/cas/store/grpc_store.rs
+++ b/cas/store/grpc_store.rs
@@ -313,7 +313,6 @@ impl GrpcStore {
             .get_action_result_from_digest(digest)
             .await
             .map(|response| response.into_inner())
-            .ok()
             .err_tip(|| "Action result not found")?;
         // TODO: Would be better to avoid all the encoding and decoding in this
         //       file, however there's no way to currently get raw bytes from a


### PR DESCRIPTION
Unexplicably, the Error context was removed when getting the upstream data from a GrpcStore.  This means that the Code::NotFound is removed and copious error messages are spewed for missing action cache entries.

Resolves #197

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/allada/turbo-cache/199)
<!-- Reviewable:end -->
