### PR TITLE
Fix default config regression in master

### DIFF
--- a/config/cas_server.rs
+++ b/config/cas_server.rs
@@ -246,6 +246,7 @@ pub struct LocalWorkerConfig {
     /// longer than this time limit, the task will be rejected. Value in seconds.
     ///
     /// Default: 1200 (seconds / 20 mins)
+    #[serde(default, deserialize_with = "convert_numeric_with_shellexpand")]
     pub max_action_timeout: usize,
 
     /// The command to execute on every execution request. This will be parsed as


### PR DESCRIPTION
Fixes minor regression where if the "max_action_timeout" was not set it would not not allow the worker to start.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/allada/turbo-cache/226)
<!-- Reviewable:end -->
