### PR TITLE
Simplify Dockerfile and prepare for Goma example

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,5 @@ target/
 */*/terraform.tfstate
 */*/.terraform
 .git
+deployment-examples
+bazel-*

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         # Which OS versions we will test on.
-        os_version: [ 20.04 ]
+        os_version: [ 20.04, 22.04 ]
     steps:
     - uses: actions/checkout@v3.5.3
       with:
@@ -38,29 +38,27 @@ jobs:
         context: .
         file: ./deployment-examples/docker-compose/Dockerfile
         build-args: |
-          OPT_LEVEL=fastbuild
           OS_VERSION=${{ matrix.os_version }}
-        # The `builder` stage is pointless to be cached because any change to the
-        # PR invalidates it. So to save the limited cache space we skip it.
-        no-cache-filters: |
-          builder-final
-        target: builder-externals-built
         load: true # This brings the build into `docker images` from buildx.
-        tags: allada/turbo-cache:test
-        cache-from: type=gha,scope=main
-        cache-to: type=gha,scope=main,mode=max
+        tags: allada/turbo-cache:dependencies
+        target: dependencies
 
-    - name: Cargo.toml is up to date
+    - name: Create container for cargo
       run: |
-        docker run --rm -e CC=clang -v $PWD:/root/turbo-cache allada/turbo-cache:test python3 ./tools/build_cargo_manifest.py && \
+        docker run --name=turbo-cache-cargo allada/turbo-cache:dependencies bash -c ' \
+          DEBIAN_FRONTEND=noninteractive apt-get install -y curl libssl-dev gcc pkg-config python3 && \
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=1.70.0 \
+        ' && \
+        docker commit turbo-cache-cargo allada/turbo-cache:cargo
+    - name: Check Cargo.toml is up to date
+      run: |
+        docker run --rm -w /root/turbo-cache -v $PWD:/root/turbo-cache allada/turbo-cache:cargo python3 ./tools/build_cargo_manifest.py && \
         git diff --exit-code || \
         (echo "Cargo.toml is out of date. Please run: python ./tools/build_cargo_manifest.py" && exit 1)
     - name: Compile & test with cargo
       run: |
-        docker run --rm -e CC=clang -v $PWD:/root/turbo-cache allada/turbo-cache:test bash -c ' \
-          apt update && apt install -y curl libssl-dev gcc pkg-config && \
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=1.70.0 && \
-          . $HOME/.cargo/env && \
+        docker run --rm -w /root/turbo-cache -v $PWD:/root/turbo-cache allada/turbo-cache:cargo bash -c ' \
+          . /root/.cargo/env && \
           cargo build --all && \
           cargo test --all \
         '
@@ -71,7 +69,7 @@ jobs:
     strategy:
       matrix:
         # Which OS versions we will test on.
-        os_version: [ 20.04 ]
+        os_version: [ 20.04, 22.04 ]
     steps:
     - uses: actions/checkout@v3.5.3
       with:
@@ -85,24 +83,76 @@ jobs:
         build-args: |
           OPT_LEVEL=fastbuild
           OS_VERSION=${{ matrix.os_version }}
-        # The `builder` stage is pointless to be cached because any change to the
-        # PR invalidates it. So to save the limited cache space we skip it.
-        no-cache-filters: |
-          builder-final
-        target: builder-externals-built
         load: true # This brings the build into `docker images` from buildx.
         tags: allada/turbo-cache:test
-        cache-from: type=gha,scope=main
-        cache-to: type=gha,scope=main,mode=max
+        target: builder
 
     - name: Bazel test
-      run: docker run --rm -e CC=clang -v $PWD:/root/turbo-cache allada/turbo-cache:test bazel test //...
+      run: docker run --rm -v $PWD:/root/turbo-cache allada/turbo-cache:test bazel test -c fastbuild //...
+
+  docker-compose-compiles-turbo-cache:
+    # The type of runner that the job will run on.
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        # Which OS versions we will test on.
+        os_version: [ 20.04, 22.04 ]
+    steps:
+    - uses: actions/checkout@v3.5.3
+      with:
+        fetch-depth: 0
+
+    - uses: docker/setup-buildx-action@v2
+    - uses: docker/build-push-action@v4
+      with:
+        context: .
+        file: ./deployment-examples/docker-compose/Dockerfile
+        build-args: |
+          OPT_LEVEL=opt
+          OS_VERSION=${{ matrix.os_version }}
+          ADDITIONAL_SETUP_WORKER_CMD=DEBIAN_FRONTEND=noninteractive apt-get install -y gcc g++ lld pkg-config python3
+        load: true # This brings the build into `docker images` from buildx.
+        tags: allada/turbo-cache:latest
+    - uses: docker/build-push-action@v4
+      with:
+        context: .
+        file: ./deployment-examples/docker-compose/Dockerfile
+        build-args: |
+          OPT_LEVEL=opt
+          OS_VERSION=${{ matrix.os_version }}
+        load: true # This brings the build into `docker images` from buildx.
+        tags: allada/turbo-cache:builder
+        target: builder
+
+    - name: Compile turbo cache with turbo cache
+      run: |
+        mkdir -p ~/.cache && \
+        cd deployment-examples/docker-compose && \
+        docker-compose up -d && \
+        cd ../../ && \
+        docker run --rm --net=host -w /root/turbo-cache -v $PWD:/root/turbo-cache allada/turbo-cache:builder sh -c ' \
+          bazel clean && \
+          bazel test //... \
+          --remote_instance_name=main \
+          --remote_cache=grpc://127.0.0.1:50051 \
+          --remote_executor=grpc://127.0.0.1:50052 \
+          --remote_default_exec_properties=cpu_count=1 \
+        ' && \
+        docker run --rm --net=host -w /root/turbo-cache -v $PWD:/root/turbo-cache allada/turbo-cache:builder sh -c ' \
+          bazel clean && \
+          bazel test //... \
+          --remote_instance_name=main \
+          --remote_cache=grpc://127.0.0.1:50051 \
+          --remote_executor=grpc://127.0.0.1:50052 \
+          --remote_default_exec_properties=cpu_count=1 \
+        ' 2>&1 | ( ! grep '         PASSED in ' ) # If we get PASSED without (cache) it means there's a cache issue.
+
   integration-tests:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
         # Which OS versions we will test on.
-        os_version: [ 20.04 ]
+        os_version: [ 20.04, 22.04 ]
     steps:
     - uses: actions/checkout@v3.5.3
       with:
@@ -116,14 +166,8 @@ jobs:
         build-args: |
           OPT_LEVEL=fastbuild
           OS_VERSION=${{ matrix.os_version }}
-        # The `builder` stage is pointless to be cached because any change to the
-        # PR invalidates it. So to save the limited cache space we skip it.
-        no-cache-filters: |
-          builder-final
         load: true # This brings the build into `docker images` from buildx.
         tags: allada/turbo-cache:latest
-        cache-from: type=gha,scope=main
-        cache-to: type=gha,scope=main,mode=max
 
     - name: Run tests
       run: ./run_integration_tests.sh
@@ -134,7 +178,7 @@ jobs:
     strategy:
       matrix:
         # Which OS versions we will test on.
-        os_version: [ 20.04 ]
+        os_version: [ 20.04, 22.04 ]
     steps:
     - uses: actions/checkout@v3.5.3
       with:
@@ -146,24 +190,19 @@ jobs:
         context: .
         file: ./deployment-examples/docker-compose/Dockerfile
         build-args: |
-          ADDITIONAL_BAZEL_FLAGS=--config=asan
           OS_VERSION=${{ matrix.os_version }}
-        # The `builder` stage is pointless to be cached because any change to the
-        # PR invalidates it. So to save the limited cache space we skip it.
-        no-cache-filters: |
-          builder-final
-        target: builder-externals-built
         load: true # This brings the build into `docker images` from buildx.
         tags: allada/turbo-cache:asan-test
-        cache-from: type=gha,scope=main
-        cache-to: type=gha,scope=main,mode=max
+        target: dependencies
 
     - name: Bazel test
       run: |
         docker run \
+          -e TURBO_CACHE_DIR=/tmp/turbo-cache \
           --rm \
-          -e CC=clang \
-          -v $PWD:/root/turbo-cache allada/turbo-cache:asan-test \
+          -w /root/turbo-cache \
+          -v $PWD:/root/turbo-cache \
+          allada/turbo-cache:asan-test \
           bazel test \
             --config=asan \
             //...

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ An extremely fast and efficient bazel cache service (CAS) written in rust.
 
 The goals of this project are:
 1. Stability - Things should work out of the box as expected
-2. Efficiency - Don't waste time on inefficiencies & low resource usage
-3. Tested - Components should have plenty of tests & each bug should be regression tested
+2. Efficiency - Don't waste time on inefficiencies &amp; low resource usage
+3. Tested - Components should have plenty of tests &amp; each bug should be regression tested
 4. Customers First - Design choices should be optimized for what customers want
 
 ## Overview
@@ -21,6 +21,13 @@ Unix based operating systems and Windows are fully supported.
 ## TL;DR
 To compile and run the server:
 ```sh
+# Install dependencies needed to compile Turbo Cache with bazel on
+# worker machine (which is this machine).
+apt install -y gcc g++ lld libssl-dev pkg-config python3
+
+# Install cargo (if needed).
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+
 # --release causes link-time-optmization to be enabled, which can take a while
 # to compile, but will result in a much faster binary.
 #
@@ -42,7 +49,7 @@ bazel test //... \
 This will cause bazel to run the commands through an all-in-one `CAS`, `scheduler` and `worker`. See [here](https://github.com/allada/turbo-cache/tree/master/config) for configuration documentation and [here](https://github.com/allada/turbo-cache/tree/main/deployment-examples/terraform) for an example of multi-node cloud deployment example.
 
 ## Example Deployments
-We currently have two example deployments in [deployment-examples directory](https://github.com/allada/turbo-cache/tree/master/deployment-examples).
+We currently have a few example deployments in [deployment-examples directory](https://github.com/allada/turbo-cache/tree/master/deployment-examples).
 
 ### Terraform
 The [terraform deployment](https://github.com/allada/turbo-cache/tree/master/deployment-examples/terraform) is the currently preferred method as it leverages a lot of AWS cloud resources to make everything much more robust.
@@ -59,7 +66,14 @@ We support building with Bazel or Cargo. Cargo **might** produce faster binaries
 ### Bazel requirements
 * Linux (most recent versions) (untested on Windows, but might work)
 * Bazel 5.0.0+
-* `libssl-dev` package installed (ie: `apt install libssl-dev` or `yum install libssl-dev`)
+* gcc
+* g++
+* lld
+* pkg-config
+* python3
+
+Runtime dependencies:
+* `libssl-dev` or `libssl1.0-dev` (depending on your distro &amp; version)
 #### Bazel building for deployment
 ```sh
 bazel build //cas

--- a/cas/store/tests/ac_utils_test.rs
+++ b/cas/store/tests/ac_utils_test.rs
@@ -64,6 +64,7 @@ mod ac_utils_tests {
             file.write_all(&expected_data)
                 .await
                 .err_tip(|| "Could not write to file")?;
+            file.sync_all().await.err_tip(|| "Could not sync file")?;
         }
         {
             // Upload our file.

--- a/deployment-examples/docker-compose/Dockerfile
+++ b/deployment-examples/docker-compose/Dockerfile
@@ -16,8 +16,6 @@
 ARG OS_VERSION=22.04
 # `--compilation_mode` to pass into bazel (eg: opt, dbg, fastbuild).
 ARG OPT_LEVEL=opt
-# Compiler to use.
-ARG CC=clang
 # Additional bazel flags.
 ARG ADDITIONAL_BAZEL_FLAGS=
 # Bash arguments my be passed in here to install any additional dependencies
@@ -25,105 +23,41 @@ ARG ADDITIONAL_BAZEL_FLAGS=
 ARG ADDITIONAL_SETUP_WORKER_CMD=
 
 
-# Builder that contains the OS dependencies.
-FROM ubuntu:${OS_VERSION} AS builder-deps
-RUN apt update && apt-get -y install curl gnupg && \
-    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
-    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
-    apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
-        ca-certificates \
+FROM ubuntu:${OS_VERSION} AS dependencies
+ARG OS_VERSION
+RUN apt update && \
+    DEBIAN_FRONTEND=noninteractive apt install --no-install-recommends -y \
+        npm \
         git \
         pkg-config \
-        libssl-dev \
-        clang \
+        $( [[ "$OS_VERSION" == "18.04" ]] && echo libssl1.0-dev || echo libssl-dev ) \
+        gcc \
+        g++ \
         python3 \
-        yarn \
-        nodejs && \
-    yarn global add @bazel/bazelisk@1.12.1 && \
-    apt-get remove yarn -y && \
-    apt-get autoremove -y && \
-    apt-get clean -y
-SHELL [ "/bin/bash", "-euo", "pipefail", "-c" ]
+        ca-certificates && \
+    npm install -g @bazel/bazelisk
 
 
-# Builder that only contains the downloaded externals.
-FROM builder-deps as builder-with-externals
+# Build the binary.
+FROM dependencies AS builder
 WORKDIR /root/turbo-cache
-ARG CC
-# Only xfer the minimum needed to query external packages.
-COPY [ "WORKSPACE", ".bazel*", "Cargo.*", ".rustfmt.toml", "BUILD", "./" ]
-COPY [ "tools/BUILD", "tools/*.bzl", "./tools/" ]
-# Download external dependencies. This is to improve docker layer caching.
-RUN bazel fetch //...
-
-
-# Builder that only contains the files related to bazel, but none of the source code.
-# This layer improves the cache hits of the following layer, since it'll bypass the next
-# layer if only the code files changed.
-FROM builder-with-externals as builder-only-bazel-and-build-files
-WORKDIR /root/turbo-cache
-COPY . .
-RUN find . -type f -regextype egrep ! -regex '.*/(BUILD|BUILD.bazel|WORKSPACE|\.bazel.*|Cargo\..*|\.rustfmt\.toml|proto/genproto.*)' -delete && \
-    find . -type d -empty -delete
-
-
-# Builder to get a list of externals and targets rarely changed that take a while to build
-# and push them into a file. This action takes a few seconds, but most of the time the
-# output file will not change between builds, which dramatically improves our layer cache
-# hits.
-FROM builder-with-externals AS builder-external-deps
-WORKDIR /root/turbo-cache
+ADD . .
 ARG OPT_LEVEL
-ARG CC
-# Copy only the BUILD files and other bazel related files.
-COPY --from=builder-only-bazel-and-build-files /root/turbo-cache/ .
-# Special case for `//proto/... because we have a bit of generated code here that runs under
-# a different platform (host platform). Since this folder rarely changes we build it as well
-# at this cache layer.
-RUN bazel cquery -c ${OPT_LEVEL} \
-            'filter("^@", deps(attr(testonly, 0, //...), 1))' \
-            --universe_scope=//... \
-            --implicit_deps=false \
-            --tool_deps=false \
-        | cut -d' ' -f1 \
-        | sort \
-        | uniq > /root/external-targets.txt && \
-    echo "//proto/..." >> /root/external-targets.txt
-
-
-# Builder for our externals and targets rarely changed that take a while to build.
-FROM builder-with-externals as builder-externals-built
-WORKDIR /root/turbo-cache
-ARG OPT_LEVEL
-ARG CC
 ARG ADDITIONAL_BAZEL_FLAGS
-COPY proto/ proto/
-COPY --from=builder-external-deps /root/external-targets.txt /root/external-targets.txt
-RUN bazel build -c ${OPT_LEVEL} ${ADDITIONAL_BAZEL_FLAGS} --target_pattern_file=/root/external-targets.txt
-
-
-# Builder to do the remaining build. At this point most of our externals should be built.
-FROM builder-externals-built as builder-final
-ARG OPT_LEVEL
-ARG CC
-ARG ADDITIONAL_BAZEL_FLAGS
-COPY . .
 RUN bazel build -c ${OPT_LEVEL} ${ADDITIONAL_BAZEL_FLAGS} //cas && \
     cp ./bazel-bin/cas/cas /root/turbo-cache-bin
 
 
 # Go back to a fresh ubuntu container and copy only the compiled binary.
-FROM ubuntu:${OS_VERSION}
-COPY --from=builder-final /root/turbo-cache-bin /usr/local/bin/turbo-cache
+FROM ubuntu:${OS_VERSION} as final
+COPY --from=builder /root/turbo-cache-bin /usr/local/bin/turbo-cache
 # Install runtime packages.
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
         libssl-dev ca-certificates
-
 # Install any specific dependencies needed by the user.
 ARG ADDITIONAL_SETUP_WORKER_CMD
-RUN bash -c "${ADDITIONAL_SETUP_WORKER_CMD}"
+RUN bash -ueo pipefail -c "${ADDITIONAL_SETUP_WORKER_CMD}"
 
 RUN mkdir -p /root/.cache/turbo-cache
 EXPOSE 50051/tcp 50052/tcp

--- a/deployment-examples/docker-compose/docker-compose.yml
+++ b/deployment-examples/docker-compose/docker-compose.yml
@@ -21,6 +21,8 @@ services:
       context: ../..
       dockerfile: ./deployment-examples/docker-compose/Dockerfile
       network: host
+      args:
+        - ADDITIONAL_SETUP_WORKER_CMD=${ADDITIONAL_SETUP_WORKER_CMD:-}
     volumes:
       - ${TURBO_CACHE_DIR:-~/.cache/turbo-cache}:/root/.cache/turbo-cache
       - type: bind
@@ -38,6 +40,8 @@ services:
       context: ../..
       dockerfile: ./deployment-examples/docker-compose/Dockerfile
       network: host
+      args:
+        - ADDITIONAL_SETUP_WORKER_CMD=${ADDITIONAL_SETUP_WORKER_CMD:-}
     volumes:
       - type: bind
         source: .
@@ -55,6 +59,8 @@ services:
       context: ../..
       dockerfile: ./deployment-examples/docker-compose/Dockerfile
       network: host
+      args:
+        - ADDITIONAL_SETUP_WORKER_CMD=${ADDITIONAL_SETUP_WORKER_CMD:-}
     volumes:
       - ${TURBO_CACHE_DIR:-~/.cache/turbo-cache}:/root/.cache/turbo-cache
       - type: bind

--- a/deployment-examples/docker-compose/worker.json
+++ b/deployment-examples/docker-compose/worker.json
@@ -20,8 +20,8 @@
       "fast_slow": {
         "fast": {
           "filesystem": {
-            "content_path": "~/.cache/turbo-cache/data-worker-test/content_path-cas",
-            "temp_path": "~/.cache/turbo-cache/data-worker-test/tmp_path-cas",
+            "content_path": "/root/.cache/turbo-cache/data-worker-test/content_path-cas",
+            "temp_path": "/root/.cache/turbo-cache/data-worker-test/tmp_path-cas",
             "eviction_policy": {
               // 10gb.
               "max_bytes": 10000000000,
@@ -43,10 +43,10 @@
       },
       "cas_fast_slow_store": "WORKER_FAST_SLOW_STORE",
       "ac_store": "GRPC_LOCAL_AC_STORE",
-      "work_directory": "~/.cache/turbo-cache/work",
+      "work_directory": "/root/.cache/turbo-cache/work",
       "platform_properties": {
         "cpu_count": {
-          "values": ["1"],
+          "query_cmd": "nproc"
         }
       }
     }

--- a/run_integration_tests.sh
+++ b/run_integration_tests.sh
@@ -56,7 +56,7 @@ cd "$SELF_DIR/deployment-examples/docker-compose"
 export UNDER_TEST_RUNNER=1
 
 # Ensure our cache locations are empty.
-rm -rf ~/.cache/turbo-cache
+sudo rm -rf ~/.cache/turbo-cache
 mkdir -p ~/.cache/turbo-cache
 
 # Ensure our docker compose is not running.
@@ -66,7 +66,7 @@ export TMPDIR=$HOME/.cache/turbo-cache/
 mkdir -p "$TMPDIR"
 export CACHE_DIR=$(mktemp -d --suffix="-turbo-cache-integration-test")
 export BAZEL_CACHE_DIR="$CACHE_DIR/bazel"
-trap "rm -rf $CACHE_DIR; docker-compose rm --stop -f" EXIT
+trap "sudo rm -rf $CACHE_DIR; docker-compose rm --stop -f" EXIT
 
 echo "" # New line.
 
@@ -78,7 +78,7 @@ mkdir -p "$TURBO_CACHE_DIR"
 for pattern in "${TEST_PATTERNS[@]}"; do
   find "$SELF_DIR/integration_tests/" -name "$pattern" -type f -print0 | while IFS= read -r -d $'\0' fullpath; do
     # Cleanup.
-    find "$TURBO_CACHE_DIR" -delete
+    sudo find "$TURBO_CACHE_DIR" -delete
     bazel --output_base="$BAZEL_CACHE_DIR" clean
     FILENAME=$(basename $fullpath)
     echo "Running test $FILENAME"


### PR DESCRIPTION
Dramatically simplifies the Dockerfile for docker-compose example, clarifies some documentation, makes tests run in 18.04, 20.04 and 22.04 and fixes a minor test flake.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/allada/turbo-cache/258)
<!-- Reviewable:end -->
