### PR TITLE
Fix potential race condition if worker disconnects

### DIFF
--- a/cas/worker/running_actions_manager.rs
+++ b/cas/worker/running_actions_manager.rs
@@ -37,7 +37,7 @@ use prost::Message;
 use relative_path::RelativePath;
 use tokio::io::{AsyncReadExt, AsyncSeekExt};
 use tokio::process;
-use tokio::sync::oneshot;
+use tokio::sync::{oneshot, watch};
 use tokio::task::spawn_blocking;
 use tokio::time::timeout;
 use tokio_stream::wrappers::ReadDirStream;
@@ -598,11 +598,19 @@ impl RunningActionImpl {
         #[cfg(target_family = "windows")]
         let envs = {
             let mut envs = command_proto.environment_variables.clone();
-            if envs.iter().any(|v| v.name == "SystemRoot") {
+            if !envs.iter().any(|v| v.name.to_uppercase() == "SYSTEMROOT") {
                 envs.push(
                     proto::build::bazel::remote::execution::v2::command::EnvironmentVariable {
                         name: "SystemRoot".to_string(),
                         value: "C:\\Windows".to_string(),
+                    },
+                );
+            }
+            if !envs.iter().any(|v| v.name.to_uppercase() == "PATH") {
+                envs.push(
+                    proto::build::bazel::remote::execution::v2::command::EnvironmentVariable {
+                        name: "PATH".to_string(),
+                        value: "C:\\Windows\\System32".to_string(),
                     },
                 );
             }
@@ -716,9 +724,15 @@ impl RunningActionImpl {
                 _ = &mut kill_channel_rx => {
                     killed_action = true;
                     if let Err(e) = child_process.start_kill() {
-                        log::error!("Could not kill process in RunningActionsManager : {:?}", e);
+                        log::error!(
+                            "Could not kill process in RunningActionsManager for action {} : {:?}",
+                            hex::encode(self.action_id),
+                            e);
                     } else {
-                        log::error!("Could not get child process id, maybe already dead?");
+                        log::error!(
+                            "Could not get child process id, maybe already dead? for action {}",
+                            hex::encode(self.action_id)
+                        );
                     }
                     {
                         let mut state = self.state.lock();
@@ -936,9 +950,17 @@ impl RunningActionImpl {
             .err_tip(|| format!("Could not remove working directory {}", self.work_directory));
         self.did_cleanup.store(true, Ordering::Relaxed);
         if let Err(e) = self.running_actions_manager.cleanup_action(&self.action_id) {
+            log::error!("Error cleaning up action: {e:?}");
             return Result::<Arc<Self>, Error>::Err(e).merge(remove_dir_result.map(|_| self));
         }
-        remove_dir_result.map(|_| self)
+        if let Err(e) = remove_dir_result {
+            log::error!(
+                "Error removing working for action {} directory: {e:?}",
+                hex::encode(self.action_id)
+            );
+            return Err(e);
+        }
+        Ok(self)
     }
 
     async fn inner_get_finished_result(self: Arc<Self>) -> Result<ActionResult, Error> {
@@ -1035,6 +1057,9 @@ pub struct RunningActionsManagerImpl {
     upload_strategy: UploadCacheResultsStrategy,
     max_action_timeout: Duration,
     running_actions: Mutex<HashMap<ActionId, Weak<RunningActionImpl>>>,
+    // Note: We don't use Notify because we need to support a .wait_for()-like function, which
+    // Notify does not support.
+    action_done_tx: watch::Sender<()>,
     callbacks: Callbacks,
     metrics: Arc<Metrics>,
 }
@@ -1057,6 +1082,7 @@ impl RunningActionsManagerImpl {
             .downcast_ref::<Arc<FilesystemStore>>()
             .err_tip(|| "Expected FilesystemStore store for .fast_store() in RunningActionsManagerImpl")?
             .clone();
+        let (action_done_tx, _) = watch::channel(());
         Ok(Self {
             root_work_directory,
             entrypoint_cmd,
@@ -1066,6 +1092,7 @@ impl RunningActionsManagerImpl {
             upload_strategy,
             max_action_timeout,
             running_actions: Mutex::new(HashMap::new()),
+            action_done_tx,
             callbacks,
             metrics: Arc::new(Metrics::default()),
         })
@@ -1135,13 +1162,16 @@ impl RunningActionsManagerImpl {
 
     fn cleanup_action(&self, action_id: &ActionId) -> Result<(), Error> {
         let mut running_actions = self.running_actions.lock();
-        running_actions
+        let result = running_actions
             .remove(action_id)
-            .err_tip(|| format!("Expected action id '{action_id:?}' to exist in RunningActionsManagerImpl"))?;
-        Ok(())
+            .err_tip(|| format!("Expected action id '{action_id:?}' to exist in RunningActionsManagerImpl"));
+        // No need to copy anything, we just are telling the receivers an event happened.
+        self.action_done_tx.send_modify(|_| {});
+        result.map(|_| ())
     }
 
     // Note: We do not capture metrics on this call, only `.kill_all()`.
+    // Important: When the future returns the process may still be running.
     async fn kill_action(action: Arc<RunningActionImpl>) {
         let kill_channel_tx = {
             let mut action_state = action.state.lock();
@@ -1149,7 +1179,7 @@ impl RunningActionsManagerImpl {
         };
         if let Some(kill_channel_tx) = kill_channel_tx {
             if kill_channel_tx.send(()).is_err() {
-                log::error!("Error sending kill to running action");
+                log::error!("Error sending kill to running action {}", hex::encode(action.action_id));
             }
         }
     }
@@ -1270,6 +1300,7 @@ impl RunningActionsManager for RunningActionsManagerImpl {
             .await
     }
 
+    // Note: When the future returns the process should be fully killed and cleaned up.
     async fn kill_all(&self) {
         self.metrics
             .kill_all
@@ -1285,7 +1316,15 @@ impl RunningActionsManager for RunningActionsManagerImpl {
                     Self::kill_action(action).await;
                 }
             })
-            .await
+            .await;
+        // Ignore error. If error happens it means there's no sender, which is not a problem.
+        // Note: Sanity check this API will always check current value then future values:
+        // https://play.rust-lang.org/?version=stable&edition=2021&gist=23103652cc1276a97e5f9938da87fdb2
+        let _ = self
+            .action_done_tx
+            .subscribe()
+            .wait_for(|_| self.running_actions.lock().is_empty())
+            .await;
     }
 
     #[inline]

--- a/cas/worker/tests/running_actions_manager_test.rs
+++ b/cas/worker/tests/running_actions_manager_test.rs
@@ -22,7 +22,7 @@ use std::io::Cursor;
 use std::os::unix::fs::{MetadataExt, PermissionsExt};
 use std::pin::Pin;
 use std::str::from_utf8;
-use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -919,7 +919,7 @@ mod running_actions_manager_tests {
         #[cfg(target_family = "unix")]
         let arguments = vec!["sh".to_string(), "-c".to_string(), "sleep infinity".to_string()];
         #[cfg(target_family = "windows")]
-        let arguments = vec!["cmd".to_string(), "/C".to_string(), "timeout 99999".to_string()];
+        let arguments = vec!["cmd".to_string(), "/C".to_string(), "Timeout 99999".to_string()];
 
         let command = Command {
             arguments,
@@ -1493,6 +1493,124 @@ exit 0
             tx.send(()).expect("Could not send timeout signal");
         });
         assert_eq!(results?.error.unwrap().code, Code::DeadlineExceeded);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn kill_all_waits_for_all_tasks_to_finish() -> Result<(), Box<dyn std::error::Error>> {
+        const WORKER_ID: &str = "foo_worker_id";
+
+        fn test_monotonic_clock() -> SystemTime {
+            static CLOCK: AtomicU64 = AtomicU64::new(0);
+            monotonic_clock(&CLOCK)
+        }
+
+        let root_work_directory = make_temp_path("root_work_directory");
+        fs::create_dir_all(&root_work_directory).await?;
+
+        let (_, _, cas_store, ac_store) = setup_stores().await?;
+        let running_actions_manager = Arc::new(RunningActionsManagerImpl::new_with_callbacks(
+            root_work_directory.clone(),
+            None,
+            Pin::into_inner(cas_store.clone()),
+            Pin::into_inner(ac_store.clone()),
+            config::cas_server::UploadCacheResultsStrategy::Never,
+            Duration::MAX,
+            Callbacks {
+                now_fn: test_monotonic_clock,
+                sleep_fn: |_duration| Box::pin(futures::future::pending()),
+            },
+        )?);
+
+        #[cfg(target_family = "unix")]
+        let arguments = vec!["sh".to_string(), "-c".to_string(), "sleep infinity".to_string()];
+        #[cfg(target_family = "windows")]
+        let arguments = vec!["cmd".to_string(), "/C".to_string(), "Timeout 99999".to_string()];
+
+        let command = Command {
+            arguments,
+            output_paths: vec![],
+            working_directory: ".".to_string(),
+            ..Default::default()
+        };
+        let command_digest = serialize_and_upload_message(&command, cas_store.as_ref()).await?;
+        let input_root_digest = serialize_and_upload_message(&Directory::default(), cas_store.as_ref()).await?;
+        let action = Action {
+            command_digest: Some(command_digest.into()),
+            input_root_digest: Some(input_root_digest.into()),
+            ..Default::default()
+        };
+        let action_digest = serialize_and_upload_message(&action, cas_store.as_ref()).await?;
+
+        let (cleanup_tx, cleanup_rx) = oneshot::channel();
+        let cleanup_was_requested = AtomicBool::new(false);
+        let action = running_actions_manager
+            .create_and_add_action(
+                WORKER_ID.to_string(),
+                StartExecute {
+                    execute_request: Some(ExecuteRequest {
+                        action_digest: Some(action_digest.into()),
+                        ..Default::default()
+                    }),
+                    salt: 0,
+                    queued_timestamp: Some(make_system_time(1000).into()),
+                },
+            )
+            .await?;
+        let execute_results_fut = action
+            .clone()
+            .prepare_action()
+            .and_then(RunningAction::execute)
+            .and_then(RunningAction::upload_results)
+            .and_then(RunningAction::get_finished_result)
+            .then(|result| async {
+                cleanup_was_requested.store(true, Ordering::Release);
+                cleanup_rx.await.expect("Could not receive cleanup signal");
+                if let Err(e) = action.cleanup().await {
+                    return Result::<ActionResult, Error>::Err(e).merge(result);
+                }
+                result
+            });
+
+        tokio::pin!(execute_results_fut);
+        {
+            // Advance the action as far as possible and ensure we are not waiting on cleanup.
+            for _ in 0..1000 {
+                assert!(futures::poll!(&mut execute_results_fut).is_pending());
+                tokio::task::yield_now().await;
+            }
+            assert_eq!(cleanup_was_requested.load(Ordering::Acquire), false);
+        }
+
+        let kill_all_fut = running_actions_manager.kill_all();
+        tokio::pin!(kill_all_fut);
+
+        {
+            // * Advance the action as far as possible.
+            // * Ensure we are now waiting on cleanup.
+            // * Ensure our kill_action is still pending.
+            while !cleanup_was_requested.load(Ordering::Acquire) {
+                // Wait for cleanup to be triggered.
+                tokio::task::yield_now().await;
+                assert!(futures::poll!(&mut execute_results_fut).is_pending());
+                assert!(futures::poll!(&mut kill_all_fut).is_pending());
+            }
+        }
+        // Allow cleanup, which allows execute_results_fut to advance.
+        cleanup_tx.send(()).expect("Could not send cleanup signal");
+        // Advance our two futures to completion now.
+        let result = execute_results_fut.await;
+        kill_all_fut.await;
+        {
+            // Ensure our results are correct.
+            let action_result = result?;
+            let err = action_result
+                .error
+                .as_ref()
+                .err_tip(|| format!("{:?}", action_result))?;
+            assert_eq!(err.code, Code::Aborted, "Expected Aborted : {action_result:?}");
+        }
 
         Ok(())
     }


### PR DESCRIPTION
In the event the worker disconnects from the scheduler, we now wait until all actions are killed before we attempt to reconnect to the scheduler. This prevents a race condition where the scheduler does not know about an action the worker is doing resulting in a potential of the scheduler sending the same action to the worker that it has not cleaned up yet.

fixes #246

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/allada/turbo-cache/266)
<!-- Reviewable:end -->
