### PR TITLE
Worker services now start after listeners to prevent error confiusion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -539,6 +539,7 @@ name = "cas"
 version = "0.0.0"
 dependencies = [
  "ac_server",
+ "async-lock",
  "axum",
  "bytestream_server",
  "capabilities_server",

--- a/README.md
+++ b/README.md
@@ -35,12 +35,6 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 
 # --release causes link-time-optmization to be enabled, which can take a while
 # to compile, but will result in a much faster binary.
-#
-# Note: If you see an error like:
-# "Could not connect to endpoint grpc://127.0.0.1:50061"
-# You can ignore it is caused because the worker & scheduler are in the same
-# process and the worker tried to connect to the scheduler before it was ready.
-# It will auto-reconnect when able and everything will work fine.
 cargo run --release --bin cas -- ./config/examples/basic_cas.json
 ```
 In a separate terminal session, run the following command to connect the running server launched above to Bazel or another BRE client:
@@ -69,7 +63,6 @@ This project can be considered ~stable~ and is currently used in production syst
 We support building with Bazel or Cargo. Cargo **might** produce faster binaries because LTO (Link Time Optimization) is enabled for release versions, where Bazel currently does not support LTO for rust.
 
 ### Bazel requirements
-* Linux (most recent versions) (untested on Windows, but might work)
 * Bazel 5.0.0+
 * gcc
 * g++

--- a/cas/BUILD
+++ b/cas/BUILD
@@ -18,6 +18,7 @@ rust_binary(
         "//util:common",
         "//util:error",
         "//util:metrics_utils",
+        "@crate_index//:async-lock",
         "@crate_index//:clap",
         "@crate_index//:drop_guard",
         "@crate_index//:env_logger",

--- a/cas/grpc_service/bytestream_server.rs
+++ b/cas/grpc_service/bytestream_server.rs
@@ -462,11 +462,9 @@ impl ByteStreamServer {
         }
 
         let digest = DigestInfo::try_new(resource_info.hash, resource_info.expected_size)?;
-        let result = tokio::spawn(async move { Pin::new(store_clone.as_ref()).has(digest).await })
-            .await
-            .err_tip(|| "Failed to join spawn")?;
 
-        let Some(item_size) = result.err_tip(|| "Failed to call .has() on store")? else {
+        let has_fut = Pin::new(store_clone.as_ref()).has(digest);
+        let Some(item_size) = has_fut.await.err_tip(|| "Failed to call .has() on store")? else {
             return Err(make_err!(Code::NotFound, "{}", "not found"));
         };
         Ok(Response::new(QueryWriteStatusResponse {

--- a/cas/worker/local_worker.rs
+++ b/cas/worker/local_worker.rs
@@ -470,6 +470,7 @@ impl<T: WorkerApiClientTrait, U: RunningActionsManager> LocalWorker<T, U> {
                     update_for_worker_stream,
                 ),
             };
+            log::warn!("Worker {} connected to scheduler", inner.worker_id);
 
             // Now listen for connections and run all other services.
             if let Err(e) = inner.run(update_for_worker_stream).await {

--- a/gencargo/cas/Cargo.toml
+++ b/gencargo/cas/Cargo.toml
@@ -19,6 +19,7 @@ path = "../../cas/cas_main.rs"
 doctest = false
 
 [dependencies]
+async-lock = { workspace = true }
 axum = { workspace = true }
 clap = { workspace = true }
 drop_guard = { workspace = true }


### PR DESCRIPTION
To prevent an error message from the worker stating it cannot connect to the scheduler due to startup ordering, we now always startup workers after schedulers are listening.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/allada/turbo-cache/275)
<!-- Reviewable:end -->
